### PR TITLE
Remove unnecessary metadata check

### DIFF
--- a/Serato-Now-Playing/serato_now_playing.py
+++ b/Serato-Now-Playing/serato_now_playing.py
@@ -999,10 +999,6 @@ def gettrack(configuration):  # pylint: disable=too-many-branches
     if 'filename' in nextmeta:
         nextmeta = nowplaying.utils.getmoremetadata(nextmeta)
 
-    if nextmeta['artist'] == CURRENTMETA['fetchedartist'] and nextmeta[
-            'title'] == CURRENTMETA['fetchedtitle']:
-        return None
-
     CURRENTMETA = nextmeta
 
     return CURRENTMETA


### PR DESCRIPTION
* This check doesn't make much sense and if the read of the file
  still didn't generate more data it would lead to a crash.

Fixes #21 