### PR TITLE
Freeze requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-cryptography
-jinja2
-lxml
-polling2
-pyinstaller
-PyQT5
-requests
-tinytag
-urllib3
+jinja2==2.11.3
+lxml==4.6.2
+pyinstaller==4.2
+PyQT5==5.15.2
+requests==2.25.1
+tinytag==1.5.0
+urllib3==1.26.4


### PR DESCRIPTION
Newer versions of PyQt5 aren't compatible with PyInstaller yet
so better to freeze it.  Also freeze the others to prevent any
other surprises.  (You _are_ using a venv, right?)