### PR TITLE
Revamp UI Handling

### DIFF
--- a/nowplaying.pyproject
+++ b/nowplaying.pyproject
@@ -1,0 +1,3 @@
+{
+    "files": ["nowplaying/resources/settings.ui","test_settingsui.py"]
+}

--- a/nowplaying.pyproject.user
+++ b/nowplaying.pyproject.user
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE QtCreatorProject>
+<!-- Written by QtCreator 4.14.2, 2021-04-20T07:56:30. -->
+<qtcreator>
+ <data>
+  <variable>EnvironmentId</variable>
+  <value type="QByteArray">{60f6bf47-0bc0-4198-9147-b63582cd81f6}</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.ActiveTarget</variable>
+  <value type="int">0</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.EditorSettings</variable>
+  <valuemap type="QVariantMap">
+   <value type="bool" key="EditorConfiguration.AutoIndent">true</value>
+   <value type="bool" key="EditorConfiguration.AutoSpacesForTabs">false</value>
+   <value type="bool" key="EditorConfiguration.CamelCaseNavigation">true</value>
+   <valuemap type="QVariantMap" key="EditorConfiguration.CodeStyle.0">
+    <value type="QString" key="language">Cpp</value>
+    <valuemap type="QVariantMap" key="value">
+     <value type="QByteArray" key="CurrentPreferences">CppGlobal</value>
+    </valuemap>
+   </valuemap>
+   <valuemap type="QVariantMap" key="EditorConfiguration.CodeStyle.1">
+    <value type="QString" key="language">QmlJS</value>
+    <valuemap type="QVariantMap" key="value">
+     <value type="QByteArray" key="CurrentPreferences">QmlJSGlobal</value>
+    </valuemap>
+   </valuemap>
+   <value type="int" key="EditorConfiguration.CodeStyle.Count">2</value>
+   <value type="QByteArray" key="EditorConfiguration.Codec">UTF-8</value>
+   <value type="bool" key="EditorConfiguration.ConstrainTooltips">false</value>
+   <value type="int" key="EditorConfiguration.IndentSize">4</value>
+   <value type="bool" key="EditorConfiguration.KeyboardTooltips">false</value>
+   <value type="int" key="EditorConfiguration.MarginColumn">80</value>
+   <value type="bool" key="EditorConfiguration.MouseHiding">true</value>
+   <value type="bool" key="EditorConfiguration.MouseNavigation">true</value>
+   <value type="int" key="EditorConfiguration.PaddingMode">1</value>
+   <value type="bool" key="EditorConfiguration.ScrollWheelZooming">true</value>
+   <value type="bool" key="EditorConfiguration.ShowMargin">false</value>
+   <value type="int" key="EditorConfiguration.SmartBackspaceBehavior">0</value>
+   <value type="bool" key="EditorConfiguration.SmartSelectionChanging">true</value>
+   <value type="bool" key="EditorConfiguration.SpacesForTabs">true</value>
+   <value type="int" key="EditorConfiguration.TabKeyBehavior">0</value>
+   <value type="int" key="EditorConfiguration.TabSize">8</value>
+   <value type="bool" key="EditorConfiguration.UseGlobal">true</value>
+   <value type="int" key="EditorConfiguration.Utf8BomBehavior">1</value>
+   <value type="bool" key="EditorConfiguration.addFinalNewLine">true</value>
+   <value type="bool" key="EditorConfiguration.cleanIndentation">true</value>
+   <value type="bool" key="EditorConfiguration.cleanWhitespace">true</value>
+   <value type="QString" key="EditorConfiguration.ignoreFileTypes">*.md, *.MD, Makefile</value>
+   <value type="bool" key="EditorConfiguration.inEntireDocument">false</value>
+   <value type="bool" key="EditorConfiguration.skipTrailingWhitespace">true</value>
+  </valuemap>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.PluginSettings</variable>
+  <valuemap type="QVariantMap">
+   <valuemap type="QVariantMap" key="AutoTest.ActiveFrameworks">
+    <value type="bool" key="AutoTest.Framework.Boost">true</value>
+    <value type="bool" key="AutoTest.Framework.Catch">true</value>
+    <value type="bool" key="AutoTest.Framework.GTest">true</value>
+    <value type="bool" key="AutoTest.Framework.QtQuickTest">true</value>
+    <value type="bool" key="AutoTest.Framework.QtTest">true</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="AutoTest.CheckStates"/>
+   <value type="int" key="AutoTest.RunAfterBuild">0</value>
+   <value type="bool" key="AutoTest.UseGlobal">true</value>
+   <valuelist type="QVariantList" key="ClangCodeModel.CustomCommandLineKey"/>
+   <value type="bool" key="ClangCodeModel.UseGlobalConfig">true</value>
+   <value type="QString" key="ClangCodeModel.WarningConfigId">Builtin.Questionable</value>
+   <valuemap type="QVariantMap" key="ClangTools">
+    <value type="bool" key="ClangTools.AnalyzeOpenFiles">true</value>
+    <value type="bool" key="ClangTools.BuildBeforeAnalysis">true</value>
+    <value type="QString" key="ClangTools.DiagnosticConfig">Builtin.DefaultTidyAndClazy</value>
+    <value type="int" key="ClangTools.ParallelJobs">12</value>
+    <valuelist type="QVariantList" key="ClangTools.SelectedDirs"/>
+    <valuelist type="QVariantList" key="ClangTools.SelectedFiles"/>
+    <valuelist type="QVariantList" key="ClangTools.SuppressedDiagnostics"/>
+    <value type="bool" key="ClangTools.UseGlobalSettings">true</value>
+   </valuemap>
+  </valuemap>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.Target.0</variable>
+  <valuemap type="QVariantMap">
+   <value type="QString" key="DeviceType">Desktop</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">{4fc5e836-9d68-4700-8b83-663f52d8d813}</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">-1</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
+   <value type="int" key="ProjectExplorer.Target.BuildConfigurationCount">0</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.DeployConfiguration.0">
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">0</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Deploy</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Deploy</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Deploy</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">1</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.DeployConfiguration.CustomData"/>
+    <value type="bool" key="ProjectExplorer.DeployConfiguration.CustomDataEnabled">false</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.DefaultDeployConfiguration</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.DeployConfigurationCount">1</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.0">
+    <value type="QString" key="Analyzer.Perf.CallgraphMode">dwarf</value>
+    <valuelist type="QVariantList" key="Analyzer.Perf.Events">
+     <value type="QString">cpu-cycles</value>
+    </valuelist>
+    <valuelist type="QVariantList" key="Analyzer.Perf.ExtraArguments"/>
+    <value type="int" key="Analyzer.Perf.Frequency">250</value>
+    <valuelist type="QVariantList" key="Analyzer.Perf.RecordArguments">
+     <value type="QString">-e</value>
+     <value type="QString">cpu-cycles</value>
+     <value type="QString">--call-graph</value>
+     <value type="QString">dwarf,4096</value>
+     <value type="QString">-F</value>
+     <value type="QString">250</value>
+    </valuelist>
+    <value type="QString" key="Analyzer.Perf.SampleMode">-F</value>
+    <value type="bool" key="Analyzer.Perf.Settings.UseGlobalSettings">true</value>
+    <value type="int" key="Analyzer.Perf.StackSize">4096</value>
+    <value type="bool" key="Analyzer.QmlProfiler.AggregateTraces">false</value>
+    <value type="bool" key="Analyzer.QmlProfiler.FlushEnabled">false</value>
+    <value type="uint" key="Analyzer.QmlProfiler.FlushInterval">1000</value>
+    <value type="QString" key="Analyzer.QmlProfiler.LastTraceFile"></value>
+    <value type="bool" key="Analyzer.QmlProfiler.Settings.UseGlobalSettings">true</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.AddedSuppressionFiles"/>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectBusEvents">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectSystime">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableBranchSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableCacheSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableEventToolTips">true</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.MinimumCostRatio">0.01</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.VisualisationMinimumCostRatio">10</value>
+    <value type="bool" key="Analyzer.Valgrind.FilterExternalIssues">true</value>
+    <value type="QString" key="Analyzer.Valgrind.KCachegrindExecutable">kcachegrind</value>
+    <value type="int" key="Analyzer.Valgrind.LeakCheckOnFinish">1</value>
+    <value type="int" key="Analyzer.Valgrind.NumCallers">25</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.RemovedSuppressionFiles"/>
+    <value type="int" key="Analyzer.Valgrind.SelfModifyingCodeDetection">1</value>
+    <value type="bool" key="Analyzer.Valgrind.Settings.UseGlobalSettings">true</value>
+    <value type="bool" key="Analyzer.Valgrind.ShowReachable">false</value>
+    <value type="bool" key="Analyzer.Valgrind.TrackOrigins">true</value>
+    <value type="QString" key="Analyzer.Valgrind.ValgrindExecutable">valgrind</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.VisibleErrorKinds">
+     <value type="int">0</value>
+     <value type="int">1</value>
+     <value type="int">2</value>
+     <value type="int">3</value>
+     <value type="int">4</value>
+     <value type="int">5</value>
+     <value type="int">6</value>
+     <value type="int">7</value>
+     <value type="int">8</value>
+     <value type="int">9</value>
+     <value type="int">10</value>
+     <value type="int">11</value>
+     <value type="int">12</value>
+     <value type="int">13</value>
+     <value type="int">14</value>
+    </valuelist>
+    <valuelist type="QVariantList" key="CustomOutputParsers"/>
+    <value type="int" key="PE.EnvironmentAspect.Base">2</value>
+    <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">test_settingsui2</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">PythonEditor.RunConfiguration./home/aw/Src/Now-Playing-Serato/test_settingsui.py</value>
+    <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">/home/aw/Src/Now-Playing-Serato/test_settingsui.py</value>
+    <value type="QString" key="PythonEditor.RunConfiguation.Interpreter">{1ec427c9-998d-4cf8-8d70-ba523f1584c2}</value>
+    <value type="QString" key="PythonEditor.RunConfiguation.Script">/home/aw/Src/Now-Playing-Serato/test_settingsui.py</value>
+    <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/home/aw/Src/Now-Playing-Serato</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.RunConfigurationCount">1</value>
+  </valuemap>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.TargetCount</variable>
+  <value type="int">1</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.Updater.FileVersion</variable>
+  <value type="int">22</value>
+ </data>
+ <data>
+  <variable>Version</variable>
+  <value type="int">22</value>
+ </data>
+</qtcreator>

--- a/nowplaying/__init__.py
+++ b/nowplaying/__init__.py
@@ -8,7 +8,7 @@ import os
 import pathlib
 import sys
 
-from PySide2.QtCore import QCoreApplication, QStandardPaths  # pylint: disable=no-name-in-module
+from PySide2.QtCore import QCoreApplication, QStandardPaths, Qt  # pylint: disable=no-name-in-module
 from PySide2.QtWidgets import QApplication  # pylint: disable=no-name-in-module
 
 import nowplaying.bootstrap
@@ -52,6 +52,7 @@ def main():
     else:
         bundledir = os.path.abspath(os.path.dirname(__file__))
 
+    QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
     qapp = QApplication(sys.argv)
     qapp.setOrganizationName('com.github.em1ran')
     qapp.setApplicationName('NowPlaying')

--- a/nowplaying/config.py
+++ b/nowplaying/config.py
@@ -51,6 +51,7 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes
             self.qsettingsformat = QSettings.NativeFormat
 
         self.iconfile = self.find_icon_file()
+        self.uifile = self.find_ui_file()
 
         self.cparser = QSettings(self.qsettingsformat, QSettings.UserScope,
                                  QCoreApplication.organizationName(),
@@ -271,6 +272,22 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes
                     return testfile
 
         logging.error('Unable to find the icon file. Death only follows.')
+        return None
+
+    def find_ui_file(self):  # pylint: disable=no-self-use
+        ''' try to find our icon '''
+
+        for testdir in [
+                ConfigFile.BUNDLEDIR,
+                os.path.join(ConfigFile.BUNDLEDIR, 'bin'),
+                os.path.join(ConfigFile.BUNDLEDIR, 'resources')
+        ]:
+            testfile = os.path.join(testdir, 'settings.ui')
+            if os.path.exists(testfile):
+                logging.debug('ui file at %s', testfile)
+                return testfile
+
+        logging.error('Unable to find the ui file. Death only follows.')
         return None
 
     def pause(self):  # pylint: disable=no-self-use

--- a/nowplaying/resources/settings.qrc
+++ b/nowplaying/resources/settings.qrc
@@ -1,0 +1,5 @@
+<RCC>
+  <qresource prefix="resources">
+    <file>icon.ico</file>
+  </qresource>
+</RCC>

--- a/nowplaying/resources/settings.ui
+++ b/nowplaying/resources/settings.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>496</width>
+    <width>512</width>
     <height>544</height>
    </rect>
   </property>
@@ -20,14 +20,14 @@
   <widget class="QTabWidget" name="settings_tabs">
    <property name="geometry">
     <rect>
-     <x>0</x>
-     <y>0</y>
-     <width>481</width>
-     <height>401</height>
+     <x>10</x>
+     <y>10</y>
+     <width>491</width>
+     <height>521</height>
     </rect>
    </property>
    <property name="currentIndex">
-    <number>0</number>
+    <number>1</number>
    </property>
    <widget class="QWidget" name="general_tab">
     <attribute name="title">
@@ -112,7 +112,7 @@
      <property name="geometry">
       <rect>
        <x>0</x>
-       <y>140</y>
+       <y>160</y>
        <width>471</width>
        <height>83</height>
       </rect>
@@ -178,7 +178,7 @@
      <property name="geometry">
       <rect>
        <x>0</x>
-       <y>240</y>
+       <y>280</y>
        <width>471</width>
        <height>52</height>
       </rect>
@@ -279,7 +279,7 @@
        <x>10</x>
        <y>230</y>
        <width>461</width>
-       <height>42</height>
+       <height>71</height>
       </rect>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
@@ -297,6 +297,9 @@
        <widget class="QLabel" name="network_info_label">
         <property name="text">
          <string/>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -437,7 +440,7 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>441</width>
+        <width>471</width>
         <height>77</height>
        </rect>
       </property>
@@ -478,9 +481,9 @@
     <widget class="QWidget" name="layoutWidget">
      <property name="geometry">
       <rect>
-       <x>8</x>
-       <y>130</y>
-       <width>461</width>
+       <x>10</x>
+       <y>110</y>
+       <width>471</width>
        <height>52</height>
       </rect>
      </property>
@@ -525,9 +528,9 @@
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>190</y>
-       <width>461</width>
-       <height>83</height>
+       <y>210</y>
+       <width>471</width>
+       <height>101</height>
       </rect>
      </property>
      <layout class="QVBoxLayout" name="serato_remote_retrieval_layout">
@@ -586,7 +589,7 @@
   <widget class="QWidget" name="horizontalLayoutWidget_2">
    <property name="geometry">
     <rect>
-     <x>0</x>
+     <x>10</x>
      <y>470</y>
      <width>491</width>
      <height>61</height>

--- a/nowplaying/resources/settings.ui
+++ b/nowplaying/resources/settings.ui
@@ -1,0 +1,948 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SettingsUI</class>
+ <widget class="QWidget" name="SettingsUI">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>496</width>
+    <height>544</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Now Playing - Settings</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="settings.qrc">
+    <normaloff>:/resources/icon.ico</normaloff>:/resources/icon.ico</iconset>
+  </property>
+  <widget class="QTabWidget" name="settings_tabs">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>481</width>
+     <height>401</height>
+    </rect>
+   </property>
+   <property name="currentIndex">
+    <number>0</number>
+   </property>
+   <widget class="QWidget" name="general_tab">
+    <attribute name="title">
+     <string>General</string>
+    </attribute>
+    <widget class="QWidget" name="layoutWidget">
+     <property name="geometry">
+      <rect>
+       <x>0</x>
+       <y>10</y>
+       <width>471</width>
+       <height>48</height>
+      </rect>
+     </property>
+     <layout class="QVBoxLayout" name="notification_layout">
+      <item>
+       <widget class="QLabel" name="notification_label">
+        <property name="text">
+         <string>**Notification Indicator**</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::MarkdownText</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="notification_checkbox">
+        <property name="text">
+         <string>Show OS system notification when new song is retrieved</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+    <widget class="QWidget" name="layoutWidget">
+     <property name="geometry">
+      <rect>
+       <x>0</x>
+       <y>70</y>
+       <width>471</width>
+       <height>59</height>
+      </rect>
+     </property>
+     <layout class="QVBoxLayout" name="read_delay_layout">
+      <item>
+       <widget class="QLabel" name="read_delay_label">
+        <property name="text">
+         <string>**Read Delay**</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::MarkdownText</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="read_delay_edit_layout">
+        <item>
+         <widget class="QLabel" name="read_delay_desc_label">
+          <property name="text">
+           <string>Amount of time in seconds to delay reading the new track info:</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="read_delay_lineedit">
+          <property name="inputMethodHints">
+           <set>Qt::ImhPreferNumbers</set>
+          </property>
+          <property name="maxLength">
+           <number>20</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+    <widget class="QWidget" name="layoutWidget">
+     <property name="geometry">
+      <rect>
+       <x>0</x>
+       <y>140</y>
+       <width>471</width>
+       <height>83</height>
+      </rect>
+     </property>
+     <layout class="QVBoxLayout" name="text_file_output_layout">
+      <item>
+       <widget class="QLabel" name="text_file_output_label">
+        <property name="text">
+         <string>**Text File Output**</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::MarkdownText</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QGridLayout" name="text_file_gridlayout">
+        <item row="1" column="2">
+         <widget class="QLineEdit" name="text_filename_lineedit"/>
+        </item>
+        <item row="1" column="1">
+         <widget class="QPushButton" name="text_saveas_button">
+          <property name="text">
+           <string>Save as ...</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="text_filename_label">
+          <property name="toolTip">
+           <string>The file to write the current the processed template.</string>
+          </property>
+          <property name="text">
+           <string>File to write</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QPushButton" name="text_template_button">
+          <property name="text">
+           <string>Browse for file ...</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="text_template_label">
+          <property name="toolTip">
+           <string>The location of the Jinja2 template to process.</string>
+          </property>
+          <property name="text">
+           <string>Text Template</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QLineEdit" name="text_template_lineedit"/>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+    <widget class="QWidget" name="layoutWidget">
+     <property name="geometry">
+      <rect>
+       <x>0</x>
+       <y>240</y>
+       <width>471</width>
+       <height>52</height>
+      </rect>
+     </property>
+     <layout class="QVBoxLayout" name="runtime_logging_layout">
+      <item>
+       <widget class="QLabel" name="runtime_logging_label">
+        <property name="text">
+         <string>**Runtime Logging**</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::MarkdownText</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="loglevel_layout">
+        <item>
+         <widget class="QLabel" name="logging_level_label">
+          <property name="toolTip">
+           <string>Now Playing writes an application log to help debug any issues. This setting controls the verbosity of the log.</string>
+          </property>
+          <property name="text">
+           <string>Level</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="logging_level_combobox">
+          <item>
+           <property name="text">
+            <string>DEBUG</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>INFO</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>WARNING</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ERROR</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>CRITICAL</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </widget>
+   <widget class="QWidget" name="http_tab">
+    <attribute name="title">
+     <string>WebServer</string>
+    </attribute>
+    <widget class="QCheckBox" name="http_enable_checkbox">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>50</y>
+       <width>70</width>
+       <height>23</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Enable</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="http_server_label">
+     <property name="geometry">
+      <rect>
+       <x>11</x>
+       <y>20</y>
+       <width>181</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>**HTTP Server Support**</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::MarkdownText</enum>
+     </property>
+    </widget>
+    <widget class="QWidget" name="layoutWidget">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>230</y>
+       <width>461</width>
+       <height>42</height>
+      </rect>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLabel" name="network_info_header_label">
+        <property name="text">
+         <string>**Networking Info**</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::MarkdownText</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="network_info_label">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+    <widget class="QWidget" name="layoutWidget">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>90</y>
+       <width>461</width>
+       <height>116</height>
+      </rect>
+     </property>
+     <layout class="QVBoxLayout" name="http_all_form_layout">
+      <item>
+       <widget class="QLabel" name="html_template_header_label">
+        <property name="text">
+         <string>**index.html Output**</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::MarkdownText</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="http_port_layout">
+        <item>
+         <widget class="QLabel" name="http_port_label">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>TCP Port</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="http_port_lineedit">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="inputMethodHints">
+           <set>Qt::ImhDigitsOnly|Qt::ImhUppercaseOnly</set>
+          </property>
+          <property name="maxLength">
+           <number>6</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QGridLayout" name="http_form_layout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="html_template_label">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>HTML Template</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QPushButton" name="html_template_button">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Browse for file ...</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QLineEdit" name="html_template_lineedit">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="http_serverpath_label">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Server Path</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QPushButton" name="http_serverpath_button">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Save to folder ...</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QLineEdit" name="http_serverpath_lineedit">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </widget>
+   <widget class="QWidget" name="serato_tab">
+    <attribute name="title">
+     <string>Serato</string>
+    </attribute>
+    <widget class="QGroupBox" name="serato_mode_groupbox">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>10</y>
+       <width>461</width>
+       <height>77</height>
+      </rect>
+     </property>
+     <property name="title">
+      <string/>
+     </property>
+     <widget class="QWidget" name="horizontalLayoutWidget_7">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>441</width>
+        <height>77</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="serato_mode_buttons_layout">
+       <item>
+        <widget class="QLabel" name="serato_mode_buttons_label">
+         <property name="text">
+          <string>**Track Retrieval Method**</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::MarkdownText</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="serato_local_button">
+         <property name="toolTip">
+          <string extracomment="Use Serato's local history log for track data"/>
+         </property>
+         <property name="text">
+          <string>Local - retrieve information from Serato data directory</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="serato_remote_button">
+         <property name="text">
+          <string>Remote - retrieve information from Serato Live Playlists</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+    <widget class="QWidget" name="layoutWidget">
+     <property name="geometry">
+      <rect>
+       <x>8</x>
+       <y>130</y>
+       <width>461</width>
+       <height>52</height>
+      </rect>
+     </property>
+     <layout class="QVBoxLayout" name="serato_local_retrieval_layout">
+      <item>
+       <widget class="QLabel" name="serato_local_session_config_label">
+        <property name="text">
+         <string>**Local Retrieval Configuration**</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::MarkdownText</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="serato_local_location_layout">
+        <item>
+         <widget class="QLabel" name="serato_local_label">
+          <property name="text">
+           <string>Serato Directory</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="serato_local_browsebutton">
+          <property name="text">
+           <string>Browse for Folder ...</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="serato_local_lineedit"/>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+    <widget class="QWidget" name="layoutWidget">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>190</y>
+       <width>461</width>
+       <height>83</height>
+      </rect>
+     </property>
+     <layout class="QVBoxLayout" name="serato_remote_retrieval_layout">
+      <item>
+       <widget class="QLabel" name="serato_remote_retrieve_label">
+        <property name="text">
+         <string>**Remote Retrieval Configuration**</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::MarkdownText</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QFormLayout" name="serato_remote_layout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="serato_remote_url_label">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>URL</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="serato_remote_url_lineedit">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="serato_remote_poll_label">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Polling IInterval</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLineEdit" name="serato_remote_poll_lineedit">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </widget>
+  </widget>
+  <widget class="QWidget" name="horizontalLayoutWidget_2">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>470</y>
+     <width>491</width>
+     <height>61</height>
+    </rect>
+   </property>
+   <layout class="QHBoxLayout" name="rcs_layout">
+    <item>
+     <widget class="QPushButton" name="reset_button">
+      <property name="toolTip">
+       <string>Reset the configuration back to defaults.</string>
+      </property>
+      <property name="text">
+       <string>Reset</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="cancel_button">
+      <property name="toolTip">
+       <string>Stop making changes and exit the settings interface.</string>
+      </property>
+      <property name="text">
+       <string>Cancel</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="save_button">
+      <property name="toolTip">
+       <string>Save and exit the current settings.</string>
+      </property>
+      <property name="text">
+       <string>Save</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QLabel" name="error_label">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>415</y>
+     <width>471</width>
+     <height>41</height>
+    </rect>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">QLabel {color: red}</string>
+   </property>
+   <property name="text">
+    <string/>
+   </property>
+   <property name="textFormat">
+    <enum>Qt::MarkdownText</enum>
+   </property>
+   <property name="wordWrap">
+    <bool>true</bool>
+   </property>
+  </widget>
+ </widget>
+ <layoutdefault spacing="6" margin="9"/>
+ <tabstops>
+  <tabstop>settings_tabs</tabstop>
+  <tabstop>read_delay_lineedit</tabstop>
+  <tabstop>text_saveas_button</tabstop>
+  <tabstop>text_filename_lineedit</tabstop>
+  <tabstop>logging_level_combobox</tabstop>
+  <tabstop>http_enable_checkbox</tabstop>
+  <tabstop>http_port_lineedit</tabstop>
+  <tabstop>html_template_button</tabstop>
+  <tabstop>html_template_lineedit</tabstop>
+  <tabstop>http_serverpath_button</tabstop>
+  <tabstop>http_serverpath_lineedit</tabstop>
+  <tabstop>serato_remote_url_lineedit</tabstop>
+  <tabstop>serato_remote_poll_lineedit</tabstop>
+  <tabstop>serato_local_browsebutton</tabstop>
+  <tabstop>serato_local_lineedit</tabstop>
+  <tabstop>reset_button</tabstop>
+  <tabstop>cancel_button</tabstop>
+  <tabstop>save_button</tabstop>
+ </tabstops>
+ <resources>
+  <include location="settings.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>serato_remote_button</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>serato_remote_poll_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>177</x>
+     <y>114</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>63</x>
+     <y>283</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>serato_remote_button</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>serato_remote_url_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>177</x>
+     <y>114</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>290</x>
+     <y>252</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>serato_remote_button</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>serato_remote_poll_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>177</x>
+     <y>114</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>290</x>
+     <y>283</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>serato_remote_button</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>serato_remote_url_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>177</x>
+     <y>114</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>26</x>
+     <y>252</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>serato_local_button</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>serato_local_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>74</x>
+     <y>70</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>68</x>
+     <y>208</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>serato_local_button</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>serato_local_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>74</x>
+     <y>70</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>468</x>
+     <y>208</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>serato_local_button</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>serato_local_browsebutton</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>74</x>
+     <y>70</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>263</x>
+     <y>208</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>http_enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>http_port_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>46</x>
+     <y>90</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>470</x>
+     <y>148</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>http_enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>http_port_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>46</x>
+     <y>90</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>302</x>
+     <y>148</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>http_enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>http_serverpath_button</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>46</x>
+     <y>90</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>237</x>
+     <y>232</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>http_enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>http_serverpath_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>46</x>
+     <y>90</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>470</x>
+     <y>232</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>http_enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>http_serverpath_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>46</x>
+     <y>90</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>69</x>
+     <y>232</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>http_enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>html_template_button</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>46</x>
+     <y>90</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>237</x>
+     <y>201</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>http_enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>html_template_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>46</x>
+     <y>90</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>69</x>
+     <y>201</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>http_enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>html_template_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>46</x>
+     <y>90</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>470</x>
+     <y>201</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <designerdata>
+  <property name="gridDeltaX">
+   <number>10</number>
+  </property>
+  <property name="gridDeltaY">
+   <number>10</number>
+  </property>
+  <property name="gridSnapX">
+   <bool>true</bool>
+  </property>
+  <property name="gridSnapY">
+   <bool>true</bool>
+  </property>
+  <property name="gridVisible">
+   <bool>true</bool>
+  </property>
+ </designerdata>
+ <slots>
+  <slot>on_reset_button()</slot>
+  <slot>on_cancel_button()</slot>
+  <slot>on_save_button()</slot>
+  <slot>on_text_template_button()</slot>
+  <slot>on_text_saveas_button()</slot>
+  <slot>on_html_template_button()</slot>
+  <slot>on_http_serverpath_button()</slot>
+  <slot>on_serato_lib_button()</slot>
+  <slot>verify_http_port()</slot>
+  <slot>verify_serato_url()</slot>
+  <slot>verify_float()</slot>
+  <slot>verify_exists()</slot>
+ </slots>
+</ui>

--- a/nowplaying/settingsui.py
+++ b/nowplaying/settingsui.py
@@ -6,29 +6,16 @@ import os
 import pathlib
 import socket
 
-# pylint: disable=no-name-in-module
-from PySide2.QtCore import Qt
-
-from PySide2.QtWidgets import \
-                            QCheckBox, \
-                            QComboBox, \
-                            QFileDialog, \
-                            QFrame, \
-                            QHBoxLayout, \
-                            QLabel, \
-                            QLineEdit, \
-                            QPushButton, \
-                            QRadioButton, \
-                            QScrollArea,\
-                            QVBoxLayout, \
-                            QWidget
-from PySide2.QtGui import QIcon, QFont
+from PySide2.QtCore import Slot, QFile  # pylint: disable=no-name-in-module
+from PySide2.QtWidgets import QFileDialog, QWidget  # pylint: disable=no-name-in-module
+from PySide2.QtGui import QIcon  # pylint: disable=no-name-in-module
+from PySide2.QtUiTools import QUiLoader  # pylint: disable=no-name-in-module
 
 import nowplaying.config
 
 
 # settings UI
-class SettingsUI:  # pylint: disable=too-many-instance-attributes
+class SettingsUI(QWidget):
     ''' create settings form window '''
 
     # Need to keep track of these values get changed by the
@@ -39,202 +26,22 @@ class SettingsUI:  # pylint: disable=too-many-instance-attributes
     httpenabled = None
     httpport = None
 
-    # pylint: disable=too-many-statements, invalid-name
     def __init__(self, tray, version):
 
         self.config = nowplaying.config.ConfigFile()
         self.iconfile = self.config.iconfile
         self.tray = tray
         self.version = version
-        self.scroll = QScrollArea()
-        self.window = QWidget()
-        self.separator1 = QFrame()
-        self.separator2 = QFrame()
-        self.separator3 = QFrame()
+        super(SettingsUI, self).__init__()
+        self.load_qtui()
+
         if not self.config.iconfile:
             self.tray.cleanquit()
-        self.scroll.setWindowIcon(QIcon(self.iconfile))
-        self.layoutV = QVBoxLayout()
-        self.layoutH0 = QHBoxLayout()
-        self.layoutH0a = QHBoxLayout()
-        self.layoutH1 = QHBoxLayout()
-        self.layoutTxtTemplate = QHBoxLayout()
-        self.layoutH4 = QHBoxLayout()
-        self.layoutH5 = QHBoxLayout()
-        self.layoutHttpEnableCheckbox = QHBoxLayout()
-        self.layoutHttpPort = QHBoxLayout()
-        self.layoutHttpHtmlTemplate = QHBoxLayout()
-        self.layoutHttpServerPath = QHBoxLayout()
-        self.layoutLogLevel = QHBoxLayout()
+        self.qtui.setWindowIcon(QIcon(self.iconfile))
 
         SettingsUI.httpenabled = self.config.httpenabled
         SettingsUI.httpport = self.config.httpport
         SettingsUI.httpdir = self.config.httpdir
-
-        self.fBold = QFont()
-        self.fBold.setBold(True)
-        self.scroll.setWindowTitle(f'Now Playing v{self.version} - Settings')
-
-        self.scroll.setWidgetResizable(True)
-        self.scroll.setWindowFlag(Qt.CustomizeWindowHint, True)
-        self.scroll.setWindowFlag(Qt.WindowCloseButtonHint, False)
-        # self.scroll.setWindowFlag(Qt.WindowMinMaxButtonsHint, False)
-        self.scroll.setWindowFlag(Qt.WindowMinimizeButtonHint, False)
-        self.scroll.setWidget(self.window)
-        self.scroll.setMinimumWidth(700)
-        self.scroll.resize(700, 825)
-
-        # error section
-        self.errLabel = QLabel()
-        self.errLabel.setStyleSheet('color: red')
-        # remote
-        self.localLabel = QLabel('Track Retrieval Mode')
-        self.localLabel.setFont(self.fBold)
-        self.layoutV.addWidget(self.localLabel)
-        self.remoteDesc = QLabel(
-            'Local mode (default) uses Serato\'s local history log for track data.\
-\nRemote mode retrieves remote track data from Serato Live Playlists.')
-        self.remoteDesc.setStyleSheet('color: grey')
-        self.layoutV.addWidget(self.remoteDesc)
-        # radios
-        self.localRadio = QRadioButton('Local')
-        self.localRadio.setChecked(True)
-        self.localRadio.toggled.connect(
-            lambda: self.on_radiobutton_select(self.localRadio))
-        self.localRadio.setMaximumWidth(60)
-
-        self.remoteRadio = QRadioButton('Remote')
-        self.remoteRadio.toggled.connect(
-            lambda: self.on_radiobutton_select(self.remoteRadio))
-        self.layoutH0.addWidget(self.localRadio)
-        self.layoutH0.addWidget(self.remoteRadio)
-        self.layoutV.addLayout(self.layoutH0)
-
-        # library path
-        self.libLabel = QLabel('Serato Library Path')
-        self.libLabel.setFont(self.fBold)
-        self.libDesc = QLabel(
-            'Location of Serato library folder.\ni.e., \\THE_PATH_TO\\_Serato_'
-        )
-        self.libDesc.setStyleSheet('color: grey')
-        self.layoutV.addWidget(self.libLabel)
-        self.layoutV.addWidget(self.libDesc)
-        self.libButton = QPushButton('Browse for folder')
-        self.layoutH0a.addWidget(self.libButton)
-        self.libButton.clicked.connect(self.on_libbutton_clicked)
-        self.libEdit = QLineEdit()
-        self.layoutH0a.addWidget(self.libEdit)
-        self.layoutV.addLayout(self.layoutH0a)
-        # url
-        self.urlLabel = QLabel('URL')
-        self.urlLabel.setFont(self.fBold)
-        self.urlDesc = QLabel(
-            'Web address of your Serato Playlist.\ne.g., https://serato.com/playlists/USERNAME/live'
-        )
-        self.urlDesc.setStyleSheet('color: grey')
-        self.layoutV.addWidget(self.urlLabel)
-        self.urlEdit = QLineEdit()
-        self.layoutV.addWidget(self.urlDesc)
-        self.layoutV.addWidget(self.urlEdit)
-        self.urlLabel.setHidden(True)
-        self.urlEdit.setHidden(True)
-        self.urlDesc.setHidden(True)
-        # separator line
-        self.separator1.setFrameShape(QFrame.HLine)
-        # self.separator.setFrameShadow(QFrame.Sunken)
-        self.layoutV.addWidget(self.separator1)
-
-        # interval
-        self.intervalLabel = QLabel('Polling Interval')
-        self.intervalLabel.setFont(self.fBold)
-        self.intervalDesc = QLabel('Amount of time, in seconds, \
-that must elapse before checking for new track info. (Default = 10.0)')
-        self.intervalDesc.setStyleSheet('color: grey')
-        self.layoutV.addWidget(self.intervalLabel)
-        self.layoutV.addWidget(self.intervalDesc)
-        self.intervalEdit = QLineEdit()
-        self.intervalEdit.setMaximumSize(40, 35)
-        self.layoutV.addWidget(self.intervalEdit)
-        self.intervalLabel.setHidden(True)
-        self.intervalDesc.setHidden(True)
-        self.intervalEdit.setHidden(True)
-
-        # notify
-        self.notifLabel = QLabel('Notification Indicator')
-        self.notifLabel.setFont(self.fBold)
-        self.layoutV.addWidget(self.notifLabel)
-        self.notifCbox = QCheckBox()
-        self.notifCbox.setMaximumWidth(25)
-        self.layoutH5.addWidget(self.notifCbox)
-        self.notifDesc = QLabel('Show OS system notification \
-when new song is retrieved.')
-        self.notifDesc.setStyleSheet('color: grey')
-        self.layoutH5.addWidget(self.notifDesc)
-        self.layoutV.addLayout(self.layoutH5)
-
-        # separator line
-        self.separator2.setFrameShape(QFrame.HLine)
-        # self.separator.setFrameShadow(QFrame.Sunken)
-        self.layoutV.addWidget(self.separator2)
-
-        # file
-        self.fileLabel = QLabel('File')
-        self.fileLabel.setFont(self.fBold)
-        self.fileDesc = QLabel(
-            'The file to which current track info is written. (Must be plain text: .txt)'
-        )
-        self.fileDesc.setStyleSheet('color: grey')
-        self.layoutV.addWidget(self.fileLabel)
-        self.layoutV.addWidget(self.fileDesc)
-        self.fileButton = QPushButton('Save as ...')
-        self.layoutH1.addWidget(self.fileButton)
-        self.fileButton.clicked.connect(self.on_filebutton_clicked)
-        self.fileEdit = QLineEdit()
-        self.layoutH1.addWidget(self.fileEdit)
-        self.layoutV.addLayout(self.layoutH1)
-
-        self.txttemplateLabel = QLabel('TXT Template')
-        self.txttemplateLabel.setFont(self.fBold)
-        self.txttemplateDesc = QLabel('Template file for text output')
-        self.txttemplateDesc.setStyleSheet('color: grey')
-        self.layoutV.addWidget(self.txttemplateLabel)
-        self.layoutV.addWidget(self.txttemplateDesc)
-        self.txttemplateButton = QPushButton('Browse for file')
-        self.layoutTxtTemplate.addWidget(self.txttemplateButton)
-        self.txttemplateButton.clicked.connect(
-            self.on_txttemplatebutton_clicked)
-        self.txttemplateEdit = QLineEdit()
-        self.layoutTxtTemplate.addWidget(self.txttemplateEdit)
-        self.layoutV.addLayout(self.layoutTxtTemplate)
-
-        # delay
-        self.delayLabel = QLabel('Write Delay')
-        self.delayLabel.setFont(self.fBold)
-        self.delayDesc = QLabel('Amount of time, in seconds, \
-to delay writing the new track info once it\'s retrieved. (Default = 0)')
-        self.delayDesc.setStyleSheet('color: grey')
-        self.layoutV.addWidget(self.delayLabel)
-        self.layoutV.addWidget(self.delayDesc)
-        self.delayEdit = QLineEdit()
-        self.delayEdit.setMaximumWidth(40)
-        self.layoutV.addWidget(self.delayEdit)
-
-        # separator line
-        self.separator3.setFrameShape(QFrame.HLine)
-        # self.separator.setFrameShadow(QFrame.Sunken)
-        self.layoutV.addWidget(self.separator3)
-
-        # HTTP Server Support
-        self.httpenabledLabel = QLabel('HTTP Server Support')
-        self.httpenabledLabel.setFont(self.fBold)
-        self.layoutV.addWidget(self.httpenabledLabel)
-        self.httpenabledCbox = QCheckBox()
-        self.httpenabledCbox.setMaximumWidth(25)
-        self.layoutHttpEnableCheckbox.addWidget(self.httpenabledCbox)
-        self.httpenabledDesc = QLabel('Enable HTTP Server')
-        self.httpenabledDesc.setStyleSheet('color: grey')
-        self.layoutHttpEnableCheckbox.addWidget(self.httpenabledDesc)
-        self.layoutV.addLayout(self.layoutHttpEnableCheckbox)
 
         try:
             hostname = socket.gethostname()
@@ -243,158 +50,109 @@ to delay writing the new track info once it\'s retrieved. (Default = 0)')
             hostname = 'Unknown Hostname'
             hostip = 'Unknown IP'
 
-        self.connectionLabel = QLabel('Networking Info')
-        self.connectionLabel.setFont(self.fBold)
-        self.connectionDesc = QLabel(
-            f'Hostname: {hostname} / IP Address:{hostip}')
-        self.connectionDesc.setStyleSheet('color: grey')
-        self.layoutV.addWidget(self.connectionLabel)
-        self.layoutV.addWidget(self.connectionDesc)
+        self.qtui.network_info_label.setText(
+            f'Hostname: {hostname} / IP: {hostip}')
 
-        self.httpportLabel = QLabel('Port')
-        self.httpportLabel.setFont(self.fBold)
-        self.httpportDesc = QLabel('TCP Port to run the server on')
-        self.httpportDesc.setStyleSheet('color: grey')
-        self.layoutV.addWidget(self.httpportLabel)
-        self.layoutV.addWidget(self.httpportDesc)
-        self.httpportEdit = QLineEdit()
-        self.httpportEdit.setMaximumWidth(60)
-        self.layoutV.addWidget(self.httpportEdit)
+        # make connections. Note that radio button flipping, etc
+        # should be in the ui file itself
 
-        self.htmltemplateLabel = QLabel('HTML Template')
-        self.htmltemplateLabel.setFont(self.fBold)
-        self.htmltemplateDesc = QLabel('Template file to format')
-        self.htmltemplateDesc.setStyleSheet('color: grey')
-        self.layoutV.addWidget(self.htmltemplateLabel)
-        self.layoutV.addWidget(self.htmltemplateDesc)
-        self.htmltemplateButton = QPushButton('Browse for file')
-        self.layoutHttpHtmlTemplate.addWidget(self.htmltemplateButton)
-        self.htmltemplateButton.clicked.connect(
-            self.on_htmltemplatebutton_clicked)
-        self.htmltemplateEdit = QLineEdit()
-        self.layoutHttpHtmlTemplate.addWidget(self.htmltemplateEdit)
-        self.layoutV.addLayout(self.layoutHttpHtmlTemplate)
+        self.connect_general_tab()
+        self.connect_webserver_tab()
+        self.connect_serato_tab()
 
-        self.httpdirLabel = QLabel('Server Path')
-        self.httpdirLabel.setFont(self.fBold)
-        self.httpdirDesc = QLabel('Location to write data')
-        self.httpdirDesc.setStyleSheet('color: grey')
-        self.layoutV.addWidget(self.httpdirLabel)
-        self.layoutV.addWidget(self.httpdirDesc)
-        self.httpdirButton = QPushButton('Save to folder...')
-        self.layoutHttpServerPath.addWidget(self.httpdirButton)
-        self.httpdirButton.clicked.connect(self.on_httpdirbutton_clicked)
-        self.httpdirEdit = QLineEdit()
-        self.layoutHttpServerPath.addWidget(self.httpdirEdit)
-        self.layoutV.addLayout(self.layoutHttpServerPath)
+    def load_qtui(self):
+        ''' Load the QtDesigner UI file '''
+        loader = QUiLoader()
+        path = os.path.join(self.config.uifile)
+        ui_file = QFile(path)
+        ui_file.open(QFile.ReadOnly)
+        self.qtui = loader.load(ui_file)
+        ui_file.close()
 
-        if self.config.loglevel == 'INFO':
-            setlogindex = 0
-        else:
-            setlogindex = 1
+    def connect_general_tab(self):
+        ''' hook up the general tab to non-built-ins '''
+        self.qtui.cancel_button.clicked.connect(self.on_cancel_button)
+        self.qtui.reset_button.clicked.connect(self.on_reset_button)
+        self.qtui.save_button.clicked.connect(self.on_save_button)
 
-        self.loglevelLabel = QLabel('Logging Level')
-        self.loglevelLabel.setFont(self.fBold)
-        self.loglevelDesc = QLabel('Verbosity of the log')
-        self.loglevelDesc.setStyleSheet('color: grey')
-        self.layoutV.addWidget(self.loglevelLabel)
-        self.layoutV.addWidget(self.loglevelDesc)
-        self.loglevelComboBox = QComboBox()
-        self.loglevelComboBox.addItem('INFO')
-        self.loglevelComboBox.addItem('DEBUG')
-        self.loglevelComboBox.setCurrentIndex(setlogindex)
-        self.loglevelComboBox.setMaximumWidth(100)
-        self.layoutLogLevel.addWidget(self.loglevelComboBox)
-        self.layoutLogLevel.setAlignment(Qt.AlignLeft)
-        self.layoutV.addLayout(self.layoutLogLevel)
+        self.qtui.text_template_button.clicked.connect(
+            self.on_text_template_button)
+        self.qtui.text_saveas_button.clicked.connect(
+            self.on_text_saveas_button)
 
-        # separator line
-        self.separatorRCS = QFrame()
-        self.separatorRCS.setFrameShape(QFrame.HLine)
-        # self.separator.setFrameShadow(QFrame.Sunken)
-        self.layoutV.addWidget(self.separatorRCS)
+    def connect_webserver_tab(self):
+        ''' connect webserver tab to non-built-ins. Note that
+            the UI file does the enable/disable of the fields here
+            based upon the Enable button '''
+        self.qtui.http_serverpath_button.clicked.connect(
+            self.on_httpdirbutton_clicked)
+        self.qtui.html_template_button.clicked.connect(
+            self.on_html_template_button)
 
-        # error area
-        self.layoutV.addWidget(self.errLabel)
-        # reset btn
-        self.resetButton = QPushButton('Reset')
-        self.resetButton.setMaximumSize(80, 35)
-        self.layoutH4.addWidget(self.resetButton)
-        self.resetButton.clicked.connect(self.on_resetbutton_clicked)
-        # cancel btn
-        self.cancelButton = QPushButton('Cancel')
-        self.cancelButton.setMaximumSize(80, 35)
-        self.layoutH4.addWidget(self.cancelButton)
-        self.cancelButton.clicked.connect(self.on_cancelbutton_clicked)
-        # save btn
-        self.saveButton = QPushButton('Save')
-        self.saveButton.setMaximumSize(80, 35)
-        self.layoutH4.addWidget(self.saveButton)
-        self.saveButton.clicked.connect(self.on_savebutton_clicked)
-        self.layoutV.addLayout(self.layoutH4)
+    def connect_serato_tab(self):
+        ''' connect serato tab to non-built-ins.  UI file
+            properly enables/disables based upon local/remote '''
 
-        self.window.setLayout(self.layoutV)
+        self.qtui.serato_local_browsebutton.clicked.connect(
+            self.on_serato_lib_button)
 
     def upd_win(self):
         ''' update the settings window '''
         self.config.get()
 
         if self.config.local:
-            self.localRadio.setChecked(True)
-            self.remoteRadio.setChecked(False)
+            self.qtui.serato_local_button.setChecked(True)
+            self.qtui.serato_remote_button.setChecked(False)
         else:
-            self.localRadio.setChecked(False)
-            self.remoteRadio.setChecked(True)
-        self.libEdit.setText(self.config.libpath)
-        self.urlEdit.setText(self.config.url)
-        self.fileEdit.setText(self.config.file)
-        self.txttemplateEdit.setText(self.config.txttemplate)
-        self.httpenabledCbox.setChecked(self.config.httpenabled)
-        self.httpportEdit.setText(str(self.config.httpport))
-        self.httpdirEdit.setText(self.config.httpdir)
-        self.htmltemplateEdit.setText(self.config.htmltemplate)
-        self.intervalEdit.setText(str(self.config.interval))
-        self.delayEdit.setText(str(self.config.delay))
-        self.notifCbox.setChecked(self.config.notif)
+            self.qtui.serato_local_button.setChecked(False)
+            self.qtui.serato_remote_button.setChecked(True)
+        self.qtui.serato_local_lineedit.setText(self.config.libpath)
+        self.qtui.serato_remote_url_lineedit.setText(self.config.url)
+        self.qtui.text_filename_lineedit.setText(self.config.file)
+        self.qtui.text_template_lineedit.setText(self.config.txttemplate)
+        self.qtui.http_enable_checkbox.setChecked(self.config.httpenabled)
+        self.qtui.http_port_lineedit.setText(str(self.config.httpport))
+        self.qtui.http_serverpath_lineedit.setText(self.config.httpdir)
+        self.qtui.html_template_lineedit.setText(self.config.htmltemplate)
+        self.qtui.serato_remote_poll_lineedit.setText(str(
+            self.config.interval))
+        self.qtui.read_delay_lineedit.setText(str(self.config.delay))
+        self.qtui.notification_checkbox.setChecked(self.config.notif)
 
     def disable_web(self):
         ''' if the web server gets in trouble, this gets called '''
-        self.errLabel.setText(
+        self.qtui.error_label.setText(
             'HTTP Server settings are invalid. Bad port? Wrong directory?')
-        self.httpenabledCbox.setChecked(False)
+        self.qtui.http_enable_checkbox.setChecked(False)
         self.upd_win()
         self.upd_conf()
 
-    # pylint: disable=too-many-locals
     def upd_conf(self):
         ''' update the configuration '''
-        local = str(self.localRadio.isChecked())
-        libpath = self.libEdit.text()
-        url = self.urlEdit.text()
-        file = self.fileEdit.text()
-        txttemplate = self.txttemplateEdit.text()
-        httpenabled = self.httpenabledCbox.isChecked()
-        httpport = int(self.httpportEdit.text())
-        httpdir = self.httpdirEdit.text()
-        htmltemplate = self.htmltemplateEdit.text()
-        interval = self.intervalEdit.text()
-        delay = self.delayEdit.text()
-        notif = self.notifCbox.isChecked()
-        loglevel = self.loglevelComboBox.currentText()
+
+        #
+        # These all need special/more handling at some point
+        #
+        httpenabled = self.qtui.http_enable_checkbox.isChecked()
+        httpport = int(self.qtui.http_port_lineedit.text())
+        httpdir = self.qtui.http_serverpath_lineedit.text()
+        interval = float(self.qtui.serato_remote_poll_lineedit.text())
+        delay = float(self.qtui.read_delay_lineedit.text())
+        loglevel = self.qtui.logging_level_combobox.currentText()
 
         self.config.put(initialized=True,
-                        local=local,
-                        libpath=libpath,
-                        url=url,
-                        file=file,
-                        txttemplate=txttemplate,
+                        local=self.qtui.serato_local_button.isChecked(),
+                        libpath=self.qtui.serato_local_lineedit.text(),
+                        url=self.qtui.serato_remote_url_lineedit.text(),
+                        file=self.qtui.text_filename_lineedit.text(),
+                        txttemplate=self.qtui.text_template_lineedit.text(),
                         httpport=httpport,
                         httpdir=httpdir,
                         httpenabled=httpenabled,
-                        htmltemplate=htmltemplate,
+                        htmltemplate=self.qtui.html_template_lineedit.text(),
                         interval=interval,
                         delay=delay,
-                        notif=notif,
+                        notif=self.qtui.notification_checkbox.isChecked(),
                         loglevel=loglevel)
 
         logging.getLogger().setLevel(loglevel)
@@ -412,138 +170,114 @@ to delay writing the new track info once it\'s retrieved. (Default = 0)')
             SettingsUI.httpenabled = httpenabled
             SettingsUI.httpdir = httpdir
 
-    def on_radiobutton_select(self, b):
-        ''' radio button action '''
-        if b.text() == 'Local':
-            self.urlLabel.setHidden(True)
-            self.urlEdit.setHidden(True)
-            self.urlDesc.setHidden(True)
-            self.intervalLabel.setHidden(True)
-            self.intervalDesc.setHidden(True)
-            self.intervalEdit.setHidden(True)
-            self.libLabel.setHidden(False)
-            self.libEdit.setHidden(False)
-            self.libDesc.setHidden(False)
-            self.libButton.setHidden(False)
-        else:
-            self.urlLabel.setHidden(False)
-            self.urlEdit.setHidden(False)
-            self.urlDesc.setHidden(False)
-            self.intervalLabel.setHidden(False)
-            self.intervalDesc.setHidden(False)
-            self.intervalEdit.setHidden(False)
-            self.libLabel.setHidden(True)
-            self.libEdit.setHidden(True)
-            self.libDesc.setHidden(True)
-            self.libButton.setHidden(True)
-
-        self.window.hide()
-        self.errLabel.setText('')
-        self.window.show()
-
-    def on_filebutton_clicked(self):
+    @Slot()
+    def on_text_saveas_button(self):
         ''' file button clicked action '''
-        startfile = self.fileEdit.text()
+        startfile = self.qtui.text_filename_lineedit.text()
         if startfile:
             startdir = os.path.dirname(startfile)
         else:
             startdir = '.'
-        filename = QFileDialog.getSaveFileName(self.window, 'Open file',
-                                               startdir, '*.txt')
+        filename = QFileDialog.getSaveFileName(self, 'Open file', startdir,
+                                               '*.txt')
         if filename:
-            self.fileEdit.setText(filename[0])
+            self.qtui.text_filename_lineedit.setText(filename[0])
 
-    def on_txttemplatebutton_clicked(self):
+    @Slot()
+    def on_text_template_button(self):
         ''' file button clicked action '''
-        startfile = self.txttemplateEdit.text()
+        startfile = self.qtui.text_template_lineedit.text()
         if startfile:
             startdir = os.path.dirname(startfile)
         else:
             startdir = os.path.join(self.config.BUNDLEDIR, "templates")
-        filename = QFileDialog.getOpenFileName(self.window, 'Open file',
+        filename = QFileDialog.getOpenFileName(self.qtui, 'Open file',
                                                startdir, '*.txt')
         if filename:
-            self.txttemplateEdit.setText(filename[0])
+            self.qtui.text_template_lineedit.setText(filename[0])
 
-    def on_libbutton_clicked(self):
+    @Slot()
+    def on_serato_lib_button(self):
         ''' lib button clicked action'''
-        startdir = self.libEdit.text()
+        startdir = self.qtui.serato_local_lineedit.text()
         if not startdir:
             startdir = str(pathlib.Path.home())
-        libdir = QFileDialog.getExistingDirectory(self.window,
+        libdir = QFileDialog.getExistingDirectory(self.qtui,
                                                   'Select directory', startdir)
         if libdir:
-            self.libEdit.setText(libdir)
+            self.qtui.serato_local_lineedit.setText(libdir)
 
+    @Slot()
     def on_httpdirbutton_clicked(self):
         ''' file button clicked action '''
         startdir = self.httpdirEdit.text()
         if not startdir:
             startdir = str(pathlib.Path.home())
-        dirname = QFileDialog.getExistingDirectory(self.window,
+        dirname = QFileDialog.getExistingDirectory(self.qtui,
                                                    'Select directory',
                                                    startdir)
         if dirname:
             self.httpdirEdit.setText(dirname)
 
-    def on_htmltemplatebutton_clicked(self):
+    @Slot()
+    def on_html_template_button(self):
         ''' file button clicked action '''
-        startfile = self.htmltemplateEdit.text()
+        startfile = self.qtui.html_template_lineedit.text()
         if startfile:
             startdir = os.path.dirname(startfile)
         else:
             startdir = os.path.join(self.config.BUNDLEDIR, "templates")
-        filename = QFileDialog.getOpenFileName(self.window, 'Open file',
+        filename = QFileDialog.getOpenFileName(self.qtui, 'Open file',
                                                startdir, '*.htm *.html')
         if filename:
-            self.htmltemplateEdit.setText(filename[0])
+            self.qtui.html_template_lineedit.setText(filename[0])
 
-    def on_cancelbutton_clicked(self):
+    @Slot()
+    def on_cancel_button(self):
         ''' cancel button clicked action '''
         if self.tray:
             self.tray.action_config.setEnabled(True)
         self.upd_win()
-        self.close()
-        self.errLabel.setText('')
+        self.qtui.close()
+        self.qtui.error_label.setText('')
 
         if not self.config.file:
             self.tray.cleanquit()
 
-    def on_resetbutton_clicked(self):
+    @Slot()
+    def on_reset_button(self):
         ''' cancel button clicked action '''
         self.config.reset()
         self.upd_win()
 
-    def on_savebutton_clicked(self):
+    @Slot()
+    def on_save_button(self):
         ''' save button clicked action '''
-        if self.remoteRadio.isChecked() and (
-                'https://serato.com/playlists' not in self.urlEdit.text() and
-                'https://www.serato.com/playlists' not in self.urlEdit.text()
-                or len(self.urlEdit.text()) < 30):
-            self.errLabel.setText('* URL is invalid')
-            self.window.hide()
-            self.window.show()
+        if self.qtui.serato_remote_button.isChecked() and (
+                'https://serato.com/playlists'
+                not in self.qtui.serato_remote_url_lineedit.text()
+                and 'https://www.serato.com/playlists'
+                not in self.qtui.serato_remote_url_lineedit.text()
+                or len(self.qtui.serato_remote_url_lineedit.text()) < 30):
+            self.qtui.error_label.setText(
+                'Serato Live Playlist URL is invalid')
             return
 
-        if self.localRadio.isChecked() and '_Serato_' not in self.libEdit.text(
-        ):
-            self.errLabel.setText(
-                '* Serato Library Path is required.  Should point to "_Serato_" folder'
+        if self.qtui.serato_local_button.isChecked(
+        ) and '_Serato_' not in self.qtui.serato_local_lineedit.text():
+            self.qtui.error_label.setText(
+                r'Serato Library Path is required.  Should point to "\_Serato\_" folder'
             )
-            self.window.hide()
-            self.window.show()
             return
 
-        if self.fileEdit.text() == "":
-            self.errLabel.setText('* File is required')
-            self.window.hide()
-            self.window.show()
+        if self.qtui.text_filename_lineedit.text() == "":
+            self.qtui.error_label.setText('File to write is required')
             return
 
         self.config.unpause()
         self.upd_conf()
         self.close()
-        self.errLabel.setText('')
+        self.qtui.error_label.setText('')
         if self.config.local:
             self.tray.action_oldestmode.setCheckable(True)
         else:
@@ -556,14 +290,14 @@ to delay writing the new track info once it\'s retrieved. (Default = 0)')
         if self.tray:
             self.tray.action_config.setEnabled(False)
         self.upd_win()
-        self.scroll.show()
-        self.scroll.setFocus()
+        self.qtui.show()
+        self.qtui.setFocus()
 
     def close(self):
         ''' close the system tray '''
         self.tray.action_config.setEnabled(True)
-        self.scroll.hide()
+        self.qtui.hide()
 
     def exit(self):
         ''' exit the tray '''
-        self.scroll.close()
+        self.qtui.close()

--- a/test_settingsui.py
+++ b/test_settingsui.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+''' test code '''
+# This Python file uses the following encoding: utf-8
+import sys
+import os
+import socket
+
+from PySide2.QtWidgets import QApplication, QWidget  # pylint: disable=no-name-in-module
+from PySide2.QtCore import QFile  # pylint: disable=no-name-in-module
+from PySide2.QtUiTools import QUiLoader  # pylint: disable=no-name-in-module
+
+
+class SettingsUI(QWidget): # pylint: disable=too-few-public-methods
+    ''' test class '''
+    def __init__(self):
+        super(SettingsUI, self).__init__()
+        self.load_ui()
+
+        try:
+            hostname = socket.gethostname()
+            hostip = socket.gethostbyname(hostname)
+        except:  # pylint: disable = bare-except
+            hostname = 'Unknown Hostname'
+            hostip = 'Unknown IP'
+
+        self.ui.network_info_label.setText(
+            f'Hostname: {hostname} / IP: {hostip}')
+
+    def load_ui(self):
+        ''' load the UI '''
+        loader = QUiLoader()
+        path = os.path.join(os.path.dirname(__file__), "nowplaying",
+                            "resources", "settings.ui")
+        ui_file = QFile(path)
+        ui_file.open(QFile.ReadOnly)
+        self.qtui = loader.load(ui_file)
+        ui_file.close()
+
+
+if __name__ == "__main__":
+    app = QApplication([])
+    widget = SettingsUI()
+    widget.qtui.show()
+    sys.exit(app.exec_())


### PR DESCRIPTION
* Replace almost all of the custom UI drawing code with
  a content from QtCreator/QtDesigner
  * UI file
  * Resource definition
  * Standard QtWidget connections in the UI file
* Switch UI from a single pane to a tabbed pane to allow
  for adding more functionality in a smaller space
  (hello laptop users!)
* basic test file for use in QtCreator
* Significant removal of many pylint errors

This change is likely just the first of many.  It needs
some cleanup.  There are likely bugs. But given that one
of the key reasons this work is being done is to enable
other features, that cleanup should happen after those
new tabs get added.