### PR TITLE
Make Serato a plug-in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include versioneer.py
 include nowplaying/version.py
+graft nowplaying/inputs
+global-exclude *.py[co]

--- a/nowplaying/__init__.py
+++ b/nowplaying/__init__.py
@@ -65,9 +65,6 @@ def main():
     config = nowplaying.config.ConfigFile(bundledir=bundledir)
     logging.getLogger().setLevel(config.loglevel)
 
-    logging.info('boot up mixmode: %s / local mode: %s ', config.getmixmode(),
-                 config.local)
-
     tray = nowplaying.systemtray.Tray()  # pylint: disable=unused-variable
     qapp.setQuitOnLastWindowClosed(False)
     exitval = qapp.exec_()

--- a/nowplaying/inputs/__init__.py
+++ b/nowplaying/inputs/__init__.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+''' Input Plugin definition '''
+
+import nowplaying.config
+
+
+class InputPlugin():
+    ''' base class of input plugins '''
+    def __init__(self, qsettings=None):
+        if qsettings:
+            self.defaults(qsettings)
+            return
+
+        self.config = nowplaying.config.ConfigFile()
+
+    def getplayingtrack(self):
+        ''' Get the currently playing track '''
+        raise NotImplementedError
+
+    def getplayingmetadata(self):
+        ''' Get the metadata of the currently playing track '''
+        raise NotImplementedError
+
+    def defaults(self, qsettings):
+        ''' set the default configuration values for this plugin '''
+        raise NotImplementedError
+
+    def validmixmodes(self):  #pylint: disable=no-self-use
+        ''' tell ui valid mixmodes '''
+        #return ['newest', 'oldest']
+
+        raise NotImplementedError
+
+    def setmixmode(self, mixmode):  #pylint: disable=no-self-use
+        ''' handle user switching the mix mode: TBD '''
+        #return mixmode
+
+        raise NotImplementedError
+
+    def getmixmode(self):  #pylint: disable=no-self-use
+        ''' return what the current mixmode is set to '''
+
+        # mixmode may only be allowed to be in one state
+        # depending upon other configuration that may be in
+        # play
+
+        #return 'newest'
+
+        raise NotImplementedError

--- a/nowplaying/settingsui.py
+++ b/nowplaying/settingsui.py
@@ -105,14 +105,6 @@ class SettingsUI(QWidget):
         ''' update the settings window '''
         self.config.get()
 
-        if self.config.local:
-            self.qtui.serato_local_button.setChecked(True)
-            self.qtui.serato_remote_button.setChecked(False)
-        else:
-            self.qtui.serato_local_button.setChecked(False)
-            self.qtui.serato_remote_button.setChecked(True)
-        self.qtui.serato_local_lineedit.setText(self.config.libpath)
-        self.qtui.serato_remote_url_lineedit.setText(self.config.url)
         self.qtui.text_filename_lineedit.setText(self.config.file)
         self.qtui.text_template_lineedit.setText(self.config.txttemplate)
 
@@ -121,8 +113,21 @@ class SettingsUI(QWidget):
         self.qtui.read_delay_lineedit.setText(str(self.config.delay))
         self.qtui.notification_checkbox.setChecked(self.config.notif)
 
+        self._upd_win_serato()
         self._upd_win_webserver()
         self._upd_win_obsws()
+
+    def _upd_win_serato(self):
+        if self.config.cparser.value('serato/local', type=bool):
+            self.qtui.serato_local_button.setChecked(True)
+            self.qtui.serato_remote_button.setChecked(False)
+        else:
+            self.qtui.serato_local_button.setChecked(False)
+            self.qtui.serato_remote_button.setChecked(True)
+        self.qtui.serato_local_lineedit.setText(
+            self.config.cparser.value('serato/libpath'))
+        self.qtui.serato_remote_url_lineedit.setText(
+            self.config.cparser.value('serato/url'))
 
     def _upd_win_webserver(self):
         ''' update the webserver settings to match config '''
@@ -180,9 +185,6 @@ class SettingsUI(QWidget):
         loglevel = self.qtui.logging_level_combobox.currentText()
 
         self.config.put(initialized=True,
-                        local=self.qtui.serato_local_button.isChecked(),
-                        libpath=self.qtui.serato_local_lineedit.text(),
-                        url=self.qtui.serato_remote_url_lineedit.text(),
                         file=self.qtui.text_filename_lineedit.text(),
                         txttemplate=self.qtui.text_template_lineedit.text(),
                         interval=interval,
@@ -194,6 +196,7 @@ class SettingsUI(QWidget):
 
         self._upd_conf_webserver()
         self._upd_conf_obsws()
+        self._upd_conf_serato()
 
     def _upd_conf_webserver(self):
         ''' update the webserver settings '''
@@ -236,6 +239,14 @@ class SettingsUI(QWidget):
                                      self.qtui.obsws_template_lineedit.text())
         self.config.cparser.setValue(
             'obsws/enabled', self.qtui.obsws_enable_checkbox.isChecked())
+
+    def _upd_conf_serato(self):
+        self.config.cparser.setValue('serato/libpath',
+                                     self.qtui.serato_local_lineedit.text())
+        self.config.cparser.setValue('serato/local',
+                                     self.qtui.serato_local_button.isChecked())
+        self.config.cparser.setValue(
+            'serato/url', self.qtui.serato_remote_url_lineedit.text())
 
     @Slot()
     def on_text_saveas_button(self):
@@ -362,10 +373,7 @@ class SettingsUI(QWidget):
         self.upd_conf()
         self.close()
         self.qtui.error_label.setText('')
-        if self.config.local:
-            self.tray.action_oldestmode.setCheckable(True)
-        else:
-            self.tray.action_oldestmode.setCheckable(False)
+        self.tray.fix_mixmode_menu()
         self.tray.action_pause.setText('Pause')
         self.tray.action_pause.setEnabled(True)
 

--- a/nowplaying/systemtray.py
+++ b/nowplaying/systemtray.py
@@ -12,7 +12,6 @@ from PySide2.QtGui import QIcon  # pylint: disable=no-name-in-module
 import nowplaying.config
 import nowplaying.db
 import nowplaying.obsws
-import nowplaying.serato
 import nowplaying.settingsui
 import nowplaying.trackpoll
 import nowplaying.utils
@@ -79,24 +78,12 @@ class Tray:  # pylint: disable=too-many-instance-attributes
         self.config.get()
         if not self.config.file:
             self.settingswindow.show()
-            if self.config.getmixmode() == 'newest':
-                self.action_newestmode.setChecked(True)
-            else:
-                self.action_oldestmode.setChecked(True)
+
         else:
-
-            if self.config.local:
-                self.action_oldestmode.setCheckable(True)
-                if self.config.getmixmode() == 'newest':
-                    self.action_newestmode.setChecked(True)
-                else:
-                    self.action_oldestmode.setChecked(True)
-            else:
-                self.action_oldestmode.setChecked(False)
-                self.action_newestmode.setChecked(True)
-
             self.action_pause.setText('Pause')
             self.action_pause.setEnabled(True)
+
+        self.fix_mixmode_menu()
 
         self.error_dialog = QErrorMessage()
 
@@ -194,18 +181,32 @@ class Tray:  # pylint: disable=too-many-instance-attributes
         self.action_pause.setText('Resume')
         self.action_pause.triggered.connect(self.unpause)
 
+    def fix_mixmode_menu(self):
+        ''' update the mixmode based upon current rules '''
+        validmixmodes = self.config.validmixmodes()
+
+        if 'oldest' in validmixmodes:
+            self.action_oldestmode.setCheckable(True)
+
+        if 'newest' in validmixmodes:
+            self.action_newestmode.setCheckable(True)
+
+        if self.config.getmixmode() == 'newest':
+            self.action_newestmode.setChecked(True)
+            self.action_oldestmode.setChecked(False)
+        else:
+            self.action_oldestmode.setChecked(True)
+            self.action_newestmode.setChecked(False)
+
     def oldestmixmode(self):  #pylint: disable=no-self-use
         ''' enable active mixing '''
-
-        self.config.get()
         self.config.setmixmode('oldest')
-        self.config.save()
+        self.fix_mixmode_menu()
 
     def newestmixmode(self):  #pylint: disable=no-self-use
         ''' enable passive mixing '''
-        self.config.get()
         self.config.setmixmode('newest')
-        self.config.save()
+        self.fix_mixmode_menu()
 
     def cleanquit(self):
         ''' quit app and cleanup '''

--- a/nowplaying/trackpoll.py
+++ b/nowplaying/trackpoll.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 ''' thread to poll music player '''
 
+import importlib
 import logging
-import os
+import pkgutil
 import time
 import threading
 
@@ -10,6 +11,7 @@ from PySide2.QtCore import Signal, QThread  # pylint: disable=no-name-in-module
 
 import nowplaying.config
 import nowplaying.db
+import nowplaying.inputs
 import nowplaying.utils
 
 
@@ -28,12 +30,29 @@ class TrackPoll(QThread):
         self.setObjectName('TrackPoll')
         self.config = nowplaying.config.ConfigFile()
         self.currentmeta = {'fetchedartist': None, 'fetchedtitle': None}
+        self.handler = None
+        self.handlername = None
+        self.plugins = {}
+        self.importplugins()
+
+    def importplugins(self):
+        ''' import all of the input plugins '''
+        def iter_ns(ns_pkg):
+            return pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + ".")
+
+        self.plugins = {
+            name: importlib.import_module(name)
+            for finder, name, ispkg in iter_ns(nowplaying.inputs)
+        }
+
+        logging.info('Plugins: %s ', self.plugins.keys())
 
     def run(self):
         ''' track polling process '''
 
         threading.current_thread().name = 'TrackPoll'
         previoustxttemplate = None
+        previoushandler = None
 
         # sleep until we have something to write
         while not self.config.file and not self.endthread and not self.config.getpause(
@@ -50,13 +69,12 @@ class TrackPoll(QThread):
                     filename=self.config.txttemplate)
                 previoustxttemplate = self.config.txttemplate
 
-            # get poll interval and then poll
-            if self.config.local:
-                interval = 1
-            else:
-                interval = self.config.interval
+            if not previoushandler or previoushandler != self.config.cparser.value(
+                    'settings/handler'):
+                previoushandler = self.config.cparser.value('settings/handler')
+                self.handler = self.plugins[
+                    f'nowplaying.inputs.{previoushandler}'].Plugin()
 
-            time.sleep(interval)
             if not self.gettrack():
                 continue
             time.sleep(self.config.delay)
@@ -71,7 +89,6 @@ class TrackPoll(QThread):
 
     def gettrack(self):  # pylint: disable=too-many-branches
         ''' get currently playing track, returns None if not new or not found '''
-        serato = None
 
         logging.debug('called gettrack')
         # check paused state
@@ -80,28 +97,8 @@ class TrackPoll(QThread):
                 break
             time.sleep(1)
 
-        if self.config.local:  # locally derived
-            # paths for session history
-            sera_dir = self.config.libpath
-            hist_dir = os.path.abspath(os.path.join(sera_dir, "History"))
-            sess_dir = os.path.abspath(os.path.join(hist_dir, "Sessions"))
-            if os.path.isdir(sess_dir):
-                logging.debug('SeratoHandler called against %s', sess_dir)
-                serato = nowplaying.serato.SeratoHandler(
-                    seratodir=sess_dir, mixmode=self.config.getmixmode())
-                logging.debug('Serato processor called')
-                serato.process_sessions()
-
-        else:  # remotely derived
-            logging.debug('SeratoHandler called against %s', self.config.url)
-            serato = nowplaying.serato.SeratoHandler(seratourl=self.config.url)
-
-        if not serato:
-            logging.debug('gettrack serato is None; returning')
-            return False
-
         logging.debug('getplayingtrack called')
-        (artist, title) = serato.getplayingtrack()
+        (artist, title) = self.handler.getplayingtrack()
 
         if not artist and not title:
             logging.debug('getplaying track was None; returning')
@@ -113,7 +110,7 @@ class TrackPoll(QThread):
             return False
 
         logging.debug('Fetching more metadata from serato')
-        nextmeta = serato.getplayingmetadata()
+        nextmeta = self.handler.getplayingmetadata()
         nextmeta['fetchedtitle'] = title
         nextmeta['fetchedartist'] = artist
 

--- a/nppyi.py
+++ b/nppyi.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 ''' bootstrap for pyinstaller-based runs
     It is setup this way so that multiprocessing
     does not go ballistic.


### PR DESCRIPTION
* establish a simple plug-in system for inputs
   * there is a lot of weirdness around how and when to init config object that needs more work
* make sure pyinstaller and setup know how to work with them
* convert serato to use this system
  * this change required untangling lots of the system with being serato specific
  * interval and UI code is still tangled and will need to be done at a later date
  * there is a lot of serato simplification that could happen but passing on that for now
* change some prints -> logging


fixes #107 