### PR TITLE
Twitch IRC Bot

### DIFF
--- a/nowplaying.pyproject
+++ b/nowplaying.pyproject
@@ -7,6 +7,8 @@
         "nowplaying/resources/settings.qrc",
         "nowplaying/resources/settings_ui.ui",
         "nowplaying/resources/source_ui.ui",
-        "nowplaying/resources/webserver_ui.ui", "test_settingsui.py"
+        "nowplaying/resources/twitchbot_ui.ui",
+        "nowplaying/resources/webserver_ui.ui",
+        "test_settingsui.py"
     ]
 }

--- a/nowplaying.pyproject.user
+++ b/nowplaying.pyproject.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.15.0, 2021-05-15T23:26:09. -->
+<!-- Written by QtCreator 4.15.0, 2021-05-22T09:24:45. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
@@ -82,6 +82,9 @@
     <valuelist type="QVariantList" key="ClangTools.SelectedFiles"/>
     <valuelist type="QVariantList" key="ClangTools.SuppressedDiagnostics"/>
     <value type="bool" key="ClangTools.UseGlobalSettings">true</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="CppEditor.QuickFix">
+    <value type="bool" key="UseGlobalSettings">true</value>
    </valuemap>
   </valuemap>
  </data>

--- a/nowplaying/config.py
+++ b/nowplaying/config.py
@@ -146,6 +146,8 @@ class ConfigFile:  # pylint: disable=too-many-instance-attributes
         settings.setValue('weboutput/httpport', '8899')
         settings.setValue('weboutput/once', True)
 
+        settings.setValue('twitchbot/enabled', False)
+
         self._defaults_input_plugins(settings)
 
     def _defaults_input_plugins(self, settings):

--- a/nowplaying/obsws.py
+++ b/nowplaying/obsws.py
@@ -3,6 +3,7 @@
     see https://github.com/Palakis/obs-websocket '''
 
 import logging
+import logging.config
 import threading
 import time
 
@@ -10,6 +11,13 @@ import obswebsocket
 import obswebsocket.requests
 
 from PySide2.QtCore import Signal, QThread  # pylint: disable=no-name-in-module
+
+logging.config.dictConfig({
+    'version': 1,
+    'disable_existing_loggers': True,
+})
+
+#pylint: disable=wrong-import-position
 
 import nowplaying.config
 import nowplaying.db
@@ -35,8 +43,8 @@ class OBSWebSocketHandler(QThread):  #pylint: disable=too-many-instance-attribut
         ''' run our thread '''
         threading.current_thread().name = 'OBSWebSocket'
 
+        logging.debug('Starting main loop')
         while not self.endthread:
-            logging.debug('Starting main loop')
             self.config.get()
 
             while self.config.getpause() or not self.config.cparser.value(

--- a/nowplaying/resources/obsws_ui.ui
+++ b/nowplaying/resources/obsws_ui.ui
@@ -211,7 +211,10 @@ p, li { white-space: pre-wrap; }
        <bool>false</bool>
       </property>
       <property name="inputMethodHints">
-       <set>Qt::ImhSensitiveData</set>
+       <set>Qt::ImhHiddenText|Qt::ImhNoAutoUppercase|Qt::ImhNoPredictiveText|Qt::ImhSensitiveData</set>
+      </property>
+      <property name="echoMode">
+       <enum>QLineEdit::Password</enum>
       </property>
      </widget>
     </item>

--- a/nowplaying/resources/twitchbot_ui.ui
+++ b/nowplaying/resources/twitchbot_ui.ui
@@ -1,0 +1,474 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>640</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <widget class="QWidget" name="formLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>40</y>
+     <width>621</width>
+     <height>161</height>
+    </rect>
+   </property>
+   <layout class="QFormLayout" name="settings_layout">
+    <item row="0" column="0">
+     <widget class="QLabel" name="channel_label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string>Channel</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <widget class="QLineEdit" name="channel_lineedit">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QLabel" name="username_label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string>Username</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <widget class="QLineEdit" name="username_lineedit">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="clientid_label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string>Client ID</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="QLineEdit" name="clientid_lineedit">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="0">
+     <widget class="QLabel" name="token_label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string>Token</string>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="1">
+     <widget class="QLineEdit" name="token_lineedit">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="echoMode">
+       <enum>QLineEdit::Password</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QLabel" name="commandchar_label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string>Command Identifier</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="1">
+     <widget class="QLineEdit" name="commandchar_lineedit">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string>!</string>
+      </property>
+      <property name="maxLength">
+       <number>1</number>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QCheckBox" name="enable_checkbox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>141</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Enable Twitch Bot</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="announce_label">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>210</y>
+     <width>103</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Track Announce</string>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="announce_lineedit">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>240</x>
+     <y>210</y>
+     <width>381</width>
+     <height>25</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="announce_button">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>140</x>
+     <y>210</y>
+     <width>83</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Template</string>
+   </property>
+  </widget>
+  <widget class="QTableWidget" name="command_perm_table">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>240</y>
+     <width>621</width>
+     <height>192</height>
+    </rect>
+   </property>
+   <property name="alternatingRowColors">
+    <bool>true</bool>
+   </property>
+   <property name="selectionBehavior">
+    <enum>QAbstractItemView::SelectRows</enum>
+   </property>
+   <column>
+    <property name="text">
+     <string>Command</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>Broadcaster</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>Moderator</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>Subscriber</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>Founder</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>Conductor</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>VIP</string>
+    </property>
+   </column>
+   <column>
+    <property name="text">
+     <string>Bits</string>
+    </property>
+   </column>
+  </widget>
+  <widget class="QWidget" name="horizontalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>440</y>
+     <width>621</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <layout class="QHBoxLayout" name="commandbuttons_layout">
+    <item>
+     <widget class="QPushButton" name="add_button">
+      <property name="text">
+       <string>Add Entry</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="del_button">
+      <property name="text">
+       <string>Delete Entry</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>channel_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>37</x>
+     <y>133</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>clientid_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>38</x>
+     <y>195</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>token_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>356</x>
+     <y>226</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>token_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>29</x>
+     <y>226</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>channel_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>356</x>
+     <y>133</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>username_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>44</x>
+     <y>164</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>username_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>356</x>
+     <y>164</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>clientid_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>356</x>
+     <y>195</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>commandchar_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>388</x>
+     <y>257</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>commandchar_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>76</x>
+     <y>257</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>announce_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>62</x>
+     <y>311</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>announce_lineedit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>388</x>
+     <y>311</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>enable_checkbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>announce_button</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>80</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>181</x>
+     <y>352</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/nowplaying/settingsui.py
+++ b/nowplaying/settingsui.py
@@ -16,7 +16,7 @@ import nowplaying.config
 
 
 # settings UI
-class SettingsUI(QWidget):
+class SettingsUI(QWidget):  # pylint: disable=too-many-public-methods
     ''' create settings form window '''
     def __init__(self, tray, version):
 
@@ -349,7 +349,7 @@ class SettingsUI(QWidget):
                     config.remove(configitem)
 
             rowcount = widget.rowCount()
-            for row in range(0, rowcount):
+            for row in range(rowcount):
                 item = widget.item(row, 0)
                 cmd = item.text()
                 cmd = f'twitchbot-command-{cmd}'

--- a/nowplaying/settingsui.py
+++ b/nowplaying/settingsui.py
@@ -7,7 +7,7 @@ import pathlib
 import socket
 
 from PySide2.QtCore import Slot, QFile, Qt  # pylint: disable=no-name-in-module
-from PySide2.QtWidgets import QErrorMessage, QFileDialog, QWidget  # pylint: disable=no-name-in-module
+from PySide2.QtWidgets import QCheckBox, QErrorMessage, QFileDialog, QTableWidgetItem, QWidget  # pylint: disable=no-name-in-module
 from PySide2.QtGui import QIcon  # pylint: disable=no-name-in-module
 from PySide2.QtUiTools import QUiLoader  # pylint: disable=no-name-in-module
 import PySide2.QtXml  # pylint: disable=unused-import, import-error, no-name-in-module
@@ -18,14 +18,6 @@ import nowplaying.config
 # settings UI
 class SettingsUI(QWidget):
     ''' create settings form window '''
-
-    # Need to keep track of these values get changed by the
-    # user.  These will get set in init.  If these values
-    # change, then trigger the webthread to reset itself
-    # to pick up the new values...
-    httpenabled = None
-    httpport = None
-
     def __init__(self, tray, version):
 
         self.config = nowplaying.config.ConfigFile()
@@ -42,14 +34,6 @@ class SettingsUI(QWidget):
             self.tray.cleanquit()
         self.qtui.setWindowIcon(QIcon(self.iconfile))
 
-        SettingsUI.httpenabled = self.config.cparser.value(
-            'weboutput/httpenabled', type=bool)
-        SettingsUI.httpport = self.config.cparser.value('weboutput/httpport',
-                                                        type=int)
-
-        # make connections. Note that radio button flipping, etc
-        # should be in the ui file itself
-
     def load_qtui(self):
         ''' load the base UI and wire it up '''
         def _load_ui(name):
@@ -64,7 +48,7 @@ class SettingsUI(QWidget):
 
         self.qtui = _load_ui('settings')
 
-        baseuis = ['general', 'source', 'webserver', 'obsws']
+        baseuis = ['general', 'source', 'webserver', 'obsws', 'twitchbot']
         pluginuis = [
             key.replace('nowplaying.inputs.', '')
             for key in self.config.plugins.keys()
@@ -127,10 +111,15 @@ class SettingsUI(QWidget):
         qobject.local_dir_button.clicked.connect(self.on_serato_lib_button)
 
     def _connect_obsws_widget(self, qobject):
-        ''' connect serato tab to non-built-ins.  UI file
-            properly enables/disables based upon local/remote '''
-
+        ''' connect obsws button to template picker'''
         qobject.template_button.clicked.connect(self.on_obsws_template_button)
+
+    def _connect_twitchbot_widget(self, qobject):
+        '''  connect twitchbot announce to template picker'''
+        qobject.announce_button.clicked.connect(
+            self.on_twitchbot_announce_button)
+        qobject.add_button.clicked.connect(self.on_twitchbot_add_button)
+        qobject.del_button.clicked.connect(self.on_twitchbot_del_button)
 
     def _connect_source_widget(self, qobject):
         ''' populate the input group box '''
@@ -163,6 +152,7 @@ class SettingsUI(QWidget):
         self._upd_win_plugins()
         self._upd_win_webserver()
         self._upd_win_obsws()
+        self._upd_win_twitchbot()
 
     def _upd_win_input(self):
         ''' this is totally wrong and will need to get dealt
@@ -206,20 +196,55 @@ class SettingsUI(QWidget):
         self.widgets['obsws'].template_lineedit.setText(
             self.config.cparser.value('obsws/template'))
 
+    def _upd_win_twitchbot(self):
+        ''' update the twitch settings '''
+
+        # needs to match ui file
+        checkboxes = [
+            'broadcaster', 'moderator', 'subscriber', 'founder', 'conductor',
+            'vip', 'bits'
+        ]
+
+        for configitem in self.config.cparser.childGroups():
+            setting = {}
+            if 'twitchbot-command-' in configitem:
+                command = configitem.replace('twitchbot-command-', '')
+                setting['command'] = command
+                for box in checkboxes:
+                    setting[box] = self.config.cparser.value(
+                        f'{configitem}/{box}', defaultValue=True, type=bool)
+                self._twitchbot_command_load(**setting)
+
+        self.widgets['twitchbot'].enable_checkbox.setChecked(
+            self.config.cparser.value('twitchbot/enabled', type=bool))
+        self.widgets['twitchbot'].clientid_lineedit.setText(
+            self.config.cparser.value('twitchbot/clientid'))
+        self.widgets['twitchbot'].channel_lineedit.setText(
+            self.config.cparser.value('twitchbot/channel'))
+        self.widgets['twitchbot'].username_lineedit.setText(
+            self.config.cparser.value('twitchbot/username'))
+        self.widgets['twitchbot'].token_lineedit.setText(
+            self.config.cparser.value('twitchbot/token'))
+        self.widgets['twitchbot'].announce_lineedit.setText(
+            self.config.cparser.value('twitchbot/announce'))
+        self.widgets['twitchbot'].commandchar_lineedit.setText(
+            self.config.cparser.value('twitchbot/commandchar'))
+
     def _upd_win_plugins(self):
         ''' tell config to trigger plugins to update windows '''
         self.config.plugins_load_settingsui(self.widgets)
 
     def disable_web(self):
         ''' if the web server gets in trouble, this gets called '''
+        self.upd_win()
         self.widgets['webserver'].enable_checkbox.setChecked(False)
         self.upd_conf()
-        self.upd_win()
         self.errormessage.showMessage(
             'HTTP Server settings are invalid. Bad port?')
 
     def disable_obsws(self):
         ''' if the OBS WebSocket gets in trouble, this gets called '''
+        self.upd_win()
         self.widgets['obsws'].enable_checkbox.setChecked(False)
         self.upd_conf()
         self.upd_win()
@@ -249,7 +274,9 @@ class SettingsUI(QWidget):
         self._upd_conf_input()
         self._upd_conf_webserver()
         self._upd_conf_obsws()
+        self._upd_conf_twitchbot()
         self._upd_conf_plugins()
+        self.config.cparser.sync()
 
     def _upd_conf_input(self):
         ''' find the text of the currently selected handler '''
@@ -270,6 +297,10 @@ class SettingsUI(QWidget):
         # itself.  Hitting stop makes it go through
         # the loop again
 
+        oldenabled = self.config.cparser.value('weboutput/httpenabled',
+                                               type=bool)
+        oldport = self.config.cparser.value('weboutput/httpport', type=int)
+
         httpenabled = self.widgets['webserver'].enable_checkbox.isChecked()
         httpport = int(self.widgets['webserver'].port_lineedit.text())
 
@@ -282,12 +313,8 @@ class SettingsUI(QWidget):
             'weboutput/once',
             self.widgets['webserver'].once_checkbox.isChecked())
 
-
-        if SettingsUI.httpport != httpport or \
-           SettingsUI.httpenabled != httpenabled:
+        if oldenabled != httpenabled or oldport != httpport:
             self.tray.restart_webprocess()
-            SettingsUI.httpport = httpport
-            SettingsUI.httpenabled = httpenabled
 
     def _upd_conf_obsws(self):
         ''' update the obsws settings '''
@@ -307,6 +334,58 @@ class SettingsUI(QWidget):
         self.config.cparser.setValue(
             'obsws/enabled', self.widgets['obsws'].enable_checkbox.isChecked())
 
+    def _upd_conf_twitchbot(self):
+        ''' update the twitch settings '''
+        def reset_commands(widget, config):
+
+            # needs to match ui file
+            checkboxes = [
+                'broadcaster', 'moderator', 'subscriber', 'founder',
+                'conductor', 'vip', 'bits'
+            ]
+
+            for configitem in config.allKeys():
+                if 'twitchbot-command-' in configitem:
+                    config.remove(configitem)
+
+            rowcount = widget.rowCount()
+            for row in range(0, rowcount):
+                item = widget.item(row, 0)
+                cmd = item.text()
+                cmd = f'twitchbot-command-{cmd}'
+                for column, cbtype in enumerate(checkboxes):
+                    item = widget.cellWidget(row, column + 1)
+                    value = item.isChecked()
+                    config.setValue(f'{cmd}/{cbtype}', value)
+
+        oldenabled = self.config.cparser.value('twitchbot/enabled', type=bool)
+        newenabled = self.widgets['twitchbot'].enable_checkbox.isChecked()
+
+        self.config.cparser.setValue('twitchbot/enabled', newenabled)
+        self.config.cparser.setValue(
+            'twitchbot/clientid',
+            self.widgets['twitchbot'].clientid_lineedit.text())
+        self.config.cparser.setValue(
+            'twitchbot/channel',
+            self.widgets['twitchbot'].channel_lineedit.text())
+        self.config.cparser.setValue(
+            'twitchbot/username',
+            self.widgets['twitchbot'].username_lineedit.text())
+        self.config.cparser.setValue(
+            'twitchbot/token', self.widgets['twitchbot'].token_lineedit.text())
+        self.config.cparser.setValue(
+            'twitchbot/announce',
+            self.widgets['twitchbot'].announce_lineedit.text())
+        self.config.cparser.setValue(
+            'twitchbot/commandchar',
+            self.widgets['twitchbot'].commandchar_lineedit.text())
+
+        reset_commands(self.widgets['twitchbot'].command_perm_table,
+                       self.config.cparser)
+
+        if oldenabled != newenabled:
+            self.tray.restart_twitchbotprocess()
+
     @Slot()
     def on_text_saveas_button(self):
         ''' file button clicked action '''
@@ -320,31 +399,35 @@ class SettingsUI(QWidget):
         if filename:
             self.widgets['general'].textoutput_lineedit.setText(filename[0])
 
-    @Slot()
-    def on_text_template_button(self):
-        ''' file button clicked action '''
-        startfile = self.widgets['general'].texttemplate_lineedit.text()
+    def template_picker(self, startfile=None, startdir=None, limit='*.txt'):
+        ''' generic code to pick a template file '''
         if startfile:
             startdir = os.path.dirname(startfile)
-        else:
-            startdir = os.path.join(self.config.getbundledir(), "templates")
+        elif not startdir:
+            startdir = os.path.join(self.config.templatedir, "templates")
         filename = QFileDialog.getOpenFileName(self.qtui, 'Open file',
-                                               startdir, '*.txt')
+                                               startdir, limit)
         if filename:
-            self.widgets['general'].texttemplate_lineedit.setText(filename[0])
+            return filename[0]
+        return None
+
+    def template_picker_lineedit(self, qwidget, limit='*.txt'):
+        ''' generic code to pick a template file '''
+        filename = self.template_picker(qwidget.text(), limit)
+        if filename:
+            qwidget.setText(filename)
+
+    @Slot()
+    def on_text_template_button(self):
+        ''' file template button clicked action '''
+        self.template_picker_lineedit(
+            self.widgets['general'].texttemplate_lineedit)
 
     @Slot()
     def on_obsws_template_button(self):
-        ''' file button clicked action '''
-        startfile = self.widgets['obsws'].template_lineedit.text()
-        if startfile:
-            startdir = os.path.dirname(startfile)
-        else:
-            startdir = os.path.join(self.config.getbundledir(), "templates")
-        filename = QFileDialog.getOpenFileName(self.qtui, 'Open file',
-                                               startdir, '*.txt')
-        if filename:
-            self.widgets['obsws'].template_lineedit.setText(filename[0])
+        ''' obsws template button clicked action '''
+        self.template_picker_lineedit(
+            self.widgets['obsws'].texttemplate_lineedit)
 
     @Slot()
     def on_serato_lib_button(self):
@@ -359,16 +442,62 @@ class SettingsUI(QWidget):
 
     @Slot()
     def on_html_template_button(self):
-        ''' file button clicked action '''
-        startfile = self.widgets['webserver'].template_lineedit.text()
-        if startfile:
-            startdir = os.path.dirname(startfile)
-        else:
-            startdir = os.path.join(self.config.getbundledir(), "templates")
-        filename = QFileDialog.getOpenFileName(self.qtui, 'Open file',
-                                               startdir, '*.htm *.html')
-        if filename:
-            self.widgets['webserver'].template_lineedit.setText(filename[0])
+        ''' html template button clicked action '''
+        self.template_picker_lineedit(
+            self.widgets['webserver'].texttemplate_lineedit,
+            limit='*.htm *.html')
+
+    @Slot()
+    def on_twitchbot_announce_button(self):
+        ''' twitchbot announce button clicked action '''
+        self.template_picker_lineedit(
+            self.widgets['twitchbot'].announce_lineedit,
+            limit='twitchbot_*.txt')
+
+    def _twitchbot_command_load(self, command=None, **kwargs):
+        if not command:
+            return
+
+        row = self.widgets['twitchbot'].command_perm_table.rowCount()
+        self.widgets['twitchbot'].command_perm_table.insertRow(row)
+        cmditem = QTableWidgetItem(command)
+        self.widgets['twitchbot'].command_perm_table.setItem(row, 0, cmditem)
+
+        # needs to match ui file
+        checkboxes = [
+            'broadcaster', 'moderator', 'subscriber', 'founder', 'conductor',
+            'vip', 'bits'
+        ]
+        checkbox = []
+        for column, cbtype in enumerate(checkboxes):  # pylint: disable=unused-variable
+            checkbox = QCheckBox()
+            if cbtype in kwargs:
+                checkbox.setChecked(kwargs[cbtype])
+            else:
+                checkbox.setChecked(True)
+            self.widgets['twitchbot'].command_perm_table.setCellWidget(
+                row, column + 1, checkbox)
+
+    @Slot()
+    def on_twitchbot_add_button(self):
+        ''' twitchbot add button clicked action '''
+        filename = self.template_picker(limit='twitchbot_*.txt')
+        if not filename:
+            return
+
+        filename = os.path.basename(filename)
+        filename = filename.replace('twitchbot_', '')
+        command = filename.replace('.txt', '')
+
+        self._twitchbot_command_load(command)
+
+    @Slot()
+    def on_twitchbot_del_button(self):
+        ''' twitchbot del button clicked action '''
+        items = self.widgets['twitchbot'].command_perm_table.selectedIndexes()
+        if items:
+            self.widgets['twitchbot'].command_perm_table.removeRow(
+                items[0].row())
 
     @Slot()
     def on_cancel_button(self):

--- a/nowplaying/templates/twitchbot_hug.txt
+++ b/nowplaying/templates/twitchbot_hug.txt
@@ -1,0 +1,1 @@
+@{{ cmduser }} sends hugs to {% for people in cmdtarget %}@{{ people }} VirtualHug {% endfor %}

--- a/nowplaying/templates/twitchbot_so.txt
+++ b/nowplaying/templates/twitchbot_so.txt
@@ -1,0 +1,2 @@
+{% if cmdtarget[1] is defined and cmdtarget[1] is not none %}Hey @{{ cmdtarget[1] }}! {% endif %}
+ Shout out to @{{ cmdtarget[0] }}! Go checkout their channel at https://twitch.tv/{{ cmdtarget[0] }}!

--- a/nowplaying/templates/twitchbot_track.txt
+++ b/nowplaying/templates/twitchbot_track.txt
@@ -1,0 +1,1 @@
+{{ artist }} - "{{ title }}"

--- a/nowplaying/templates/twitchbot_trackdetail.txt
+++ b/nowplaying/templates/twitchbot_trackdetail.txt
@@ -1,0 +1,17 @@
+{% if cmdtarget[0] is defined and cmdtarget[0] is not none %}Hey @{{ cmdtarget[0] }} this song has these details... {% endif %}
+"{{ title }}"
+{% if artist is defined and artist is not none %} by {{ artist }}.{% endif %}
+{% if track is defined and track is not none %} It is track #{{ track }}
+{% if track_total is defined and track_total is not none%} out of {{ track_total }} {% endif %}{% endif %}
+{% if album is defined and album is not none %} on the album _{{ album }}_ {% endif %}
+{% if disc is defined and disc is not none %} on disc #{{ disc }}
+{% if disc_total is defined and disc_total is not none%} out of {{ disc_total }}{% endif %}. {% endif %}
+{% if albumartist is defined and albumartist is not none %} The album artist is listed as {{ albumartist }}. {% endif %}
+{% if lang is defined and lang is not none %} The language is {{ lang }}.{% endif %}
+{% if genre is defined and genre is not none %} It is classified as {{ genre }} by some people. {% endif %}
+{% if bpm is defined and bpm is not none %}The BPM is approximately {{ bpm }}.{% endif %}
+{% if key is defined and key is not none %}Performed in the key of {{ key }}{% endif %}
+{% if composer is defined and composer is not none %} {{ composer }} is the composer listing. {% endif %}
+{% if publisher is defined and publisher is not none %} It was published by {{ publisher }}.{% endif %}
+{% if year is defined and year is not none %}The year is listed as {{ year }}, but that might be
+ the year of the media. {% endif %}

--- a/nowplaying/trackpoll.py
+++ b/nowplaying/trackpoll.py
@@ -76,7 +76,7 @@ class TrackPoll(QThread):
     def gettrack(self):  # pylint: disable=too-many-branches
         ''' get currently playing track, returns None if not new or not found '''
 
-        logging.debug('called gettrack')
+        #logging.debug('called gettrack')
         # check paused state
         while True:
             if not self.config.getpause():

--- a/nowplaying/twitchbot.py
+++ b/nowplaying/twitchbot.py
@@ -35,6 +35,10 @@ from watchdog.observers import Observer
 from watchdog.events import PatternMatchingEventHandler
 from PySide2.QtCore import QCoreApplication, QStandardPaths, Qt  # pylint: disable=no-name-in-module
 
+#
+# quiet down our imports
+#
+
 logging.config.dictConfig({
     'version': 1,
     'disable_existing_loggers': True,
@@ -45,8 +49,9 @@ logging.config.dictConfig({
 import nowplaying.config
 import nowplaying.db
 
-# enable 2FA
-# register your application
+# 1. create a bot account, be sure to enable multiple logins per email
+# 2. enable 2FA
+# 3. go to dev.twitch.tv to register your application
 #   1. name (this will be the login username for the bot, the name in chat will be the account name)
 #   2. http://localhost
 #   3. Category: Chat bot

--- a/nowplaying/twitchbot.py
+++ b/nowplaying/twitchbot.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+'''
+
+This code originally:
+
+Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"). You may not
+use this file except in compliance with the License. A copy of the License
+is located at
+
+    http://aws.amazon.com/apache2.0/
+
+or in the "license" file accompanying this file. This file is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and
+limitations under the License.
+'''
+
+import logging
+import logging.config
+import logging.handlers
+import os
+import secrets
+import signal
+import string
+import sys
+import threading
+import time
+
+import irc.bot
+import jinja2
+import requests
+from watchdog.observers import Observer
+from watchdog.events import PatternMatchingEventHandler
+from PySide2.QtCore import QCoreApplication, QStandardPaths, Qt  # pylint: disable=no-name-in-module
+
+logging.config.dictConfig({
+    'version': 1,
+    'disable_existing_loggers': True,
+})
+
+#pylint: disable=wrong-import-position
+
+import nowplaying.config
+import nowplaying.db
+
+# enable 2FA
+# register your application
+#   1. name (this will be the login username for the bot, the name in chat will be the account name)
+#   2. http://localhost
+#   3. Category: Chat bot
+#   4. Create
+#   5. go into manage  clientid is now there
+# username and clientid  comes from https://dev.twitch.tv/console/apps/create
+# token comes from http://twitchapps.com/tmi/
+#
+
+
+class TwitchBot(irc.bot.SingleServerIRCBot):  # pylint: disable=too-many-instance-attributes
+    ''' twitch bot '''
+    def __init__(self, username, client_id, token, channel):
+        self.client_id = client_id
+        self.token = token.removeprefix("oauth:")
+        self.channel = '#' + channel.lower()
+        self.event_handler = None
+        self.observer = None
+        self.templatedir = os.path.join(
+            QStandardPaths.standardLocations(
+                QStandardPaths.DocumentsLocation)[0],
+            QCoreApplication.applicationName(), 'templates')
+        self.metadb = nowplaying.db.MetadataDB()
+        self.config = nowplaying.config.ConfigFile()
+        self.magiccommand = ''.join(
+            secrets.choice(string.ascii_letters) for i in range(32))
+        logging.info('Secret command to quit twitchbot: %s', self.magiccommand)
+
+        threading.current_thread().name = 'TwitchBot'
+
+        self.jinja2 = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(self.templatedir),
+            autoescape=jinja2.select_autoescape(['htm', 'html', 'xml']))
+
+        # Get the channel id, we will need this for v5 API calls
+        url = 'https://api.twitch.tv/kraken/users?login=' + channel
+        headers = {
+            'Client-ID': client_id,
+            'Accept': 'application/vnd.twitchtv.v5+json'
+        }
+        req = requests.get(url, headers=headers).json()
+        if 'error' in req:
+            logging.error('%s %s: %s', req['status'], req['error'],
+                          req['message'])
+            sys.exit(0)
+        self.channel_id = req['users'][0]['_id']
+
+        logging.debug('channel_id %s', self.channel_id)
+        # Create IRC bot connection
+        server = 'irc.chat.twitch.tv'
+        port = 6667
+        logging.info('Connecting to %s on port %d', server, port)
+        irc.bot.SingleServerIRCBot.__init__(self,
+                                            [(server, port, 'oauth:' + token)],
+                                            username, username)
+        self._setup_timer()
+
+    def _setup_timer(self):
+        watchfile = self.config.cparser.value('textoutput/file')
+        self.event_handler = PatternMatchingEventHandler(
+            patterns=[os.path.basename(watchfile)],
+            ignore_patterns=None,
+            ignore_directories=True,
+            case_sensitive=False)
+        self.event_handler.on_closed = self._announce_track
+        self.observer = Observer()
+        self.observer.schedule(self.event_handler,
+                               os.path.dirname(watchfile),
+                               recursive=False)
+        self.observer.start()
+
+    def _announce_track(self, filename):  # pylint: disable=unused-argument
+        ''' announce new tracks '''
+        self.config.get()
+        filecheck = self.config.cparser.value('textoutput/file')
+
+        if not os.path.exists(filecheck) or os.stat(filecheck).st_size == 0:
+            return
+
+        logging.info('Announcing %s',
+                     self.config.cparser.value('twitchbot/announce'))
+        if not self.config.cparser.value('twitchbot/enabled', type=bool):
+            self.shutdown()
+        self._post_template(
+            os.path.basename(self.config.cparser.value('twitchbot/announce')))
+
+    def on_welcome(self, connection, event):  # pylint: disable=unused-argument
+        ''' join the IRC channel and set up our stuff '''
+        logging.info('Joining %s', self.channel)
+
+        # You must request specific capabilities before you can use them
+        connection.cap('REQ', ':twitch.tv/membership')
+        connection.cap('REQ', ':twitch.tv/tags')
+        connection.cap('REQ', ':twitch.tv/commands')
+        connection.join(self.channel)
+        logging.info('Successfully joined %s', self.channel)
+
+    def on_pubmsg(self, connection, event):  # pylint: disable=unused-argument
+        ''' find commands '''
+        self.config.get()
+        commandchar = self.config.cparser.value('twitchbot/commandchar')
+        if not self.config.cparser.value('twitchbot/enabled', type=bool):
+            self.shutdown()
+        if not commandchar:
+            commandchar = '!'
+            self.config.cparser.setValue('twitchbot/commandchar', '!')
+        if event.arguments[0][:1] == commandchar:
+            cmd = event.arguments[0].split(' ')[0][1:]
+            logging.info('Received command: %s', cmd)
+            self.do_command(event, cmd)
+
+    def _build_user_profile(self, event):  #pylint: disable=no-self-use
+        # Get the channel id, we will need this for v5 API calls
+        tags = event.tags
+        result = {}
+        for entry in tags:
+            result.update({entry['key']: entry['value']})
+
+        logging.debug('chat profile: %s', result)
+        # frankly, twitch's information that they share on IRC
+        # seems pretty dumb. the only way to figure out the status
+        # of someone is to check the badge, but then they don't
+        # seem to actually publish a list of badges that are available
+        # so you have to do a lot of guesswork to figure out what
+        # does/doesn't work
+        #
+        # in any case, this code takes the badges field and breaks
+        # it apart and tries to make it easier to deal with later on
+        if 'badges' in result:
+            result['badgesdict'] = {}
+            for badge in result['badges'].split(','):
+                badgetype, number = badge.split('/')
+                number = int(number)
+                result['badgesdict'][badgetype.lower()] = number
+        return result
+
+    def _post_template(self, template=None, moremetadata=None):
+        if not template:
+            return
+        metadata = self.metadb.read_last_meta()
+        if not metadata:
+            metadata = {}
+        if 'coverimageraw' in metadata:
+            del metadata['coverimageraw']
+        metadata['cmdtarget'] = None
+
+        if moremetadata:
+            metadata.update(moremetadata)
+
+        if os.path.isfile(os.path.join(self.templatedir, template)):
+            template = self.jinja2.get_template(template)
+            message = template.render(metadata)
+            message = message.replace('\n', '')
+            message = message.replace('\r', '')
+            self.connection.privmsg(self.channel, str(message).strip())
+
+    def do_command(self, event, command):  # pylint: disable=unused-argument
+        ''' process a command '''
+        fullstring = event.arguments[0]
+        profile = self._build_user_profile(event)
+        metadata = {'cmduser': profile['display-name']}
+        print(profile)
+        commands = fullstring.split()
+        commands[0] = commands[0][1:]
+        metadata['cmdtarget'] = []
+        if len(commands) > 1:
+            for usercheck in commands[1:]:
+                if usercheck[0] == '@':
+                    metadata['cmdtarget'].append(usercheck[1:])
+                else:
+                    metadata['cmdtarget'].append(usercheck)
+
+        cmdfile = f'twitchbot_{commands[0]}.txt'
+
+        self.config.get()
+        self.config.cparser.beginGroup(f'twitchbot-commands-{commands[0]}')
+        perms = {}
+        for key in self.config.cparser.childKeys():
+            print(f'reading {key}')
+            perms[key] = self.config.cparser.value(key, type=bool)
+        self.config.cparser.endGroup()
+
+        allowed = True
+        if perms:
+            print('got perms')
+            allowed = False
+            for usertype in perms.items():
+                if 'badgesdict' in profile and usertype in profile[
+                        'badgesdict']:
+                    print(f'{usertype} in profile')
+                    allowed = True
+        else:
+            print('no custom perms defined')
+
+        if not allowed:
+            return
+
+        if commands[0] == self.magiccommand:
+            self.shutdown()
+
+        self._post_template(cmdfile, moremetadata=metadata)
+
+    def shutdown(self):  # pylint: disable=no-self-use
+        '''
+        logging.info('Would shutdown but not sure how')'''
+        self.observer.stop()
+        self.observer.join()
+        sys.exit(0)
+
+
+class TwitchBotHandler():
+    ''' Now Playing built-in web server using custom handler '''
+    def __init__(self, config=None):
+        self.config = config
+        self.server = None
+        self.endthread = False
+        signal.signal(signal.SIGINT, self.stop)
+
+    def run(self):  # pylint: disable=too-many-branches, too-many-statements
+        '''
+            run & configure a twitch bot
+
+            The sleeps are here to make sure we don't
+            tie up a CPU constantly checking on
+            status.  If we cannot open the port or
+            some other situation, we bring everything
+            to a halt by triggering pause.
+
+            But in general:
+
+                - web server thread starts
+                - check if web serving is running
+                - if so, open ANOTHER thread (MixIn) that will
+                  serve connections concurrently
+                - if the settings change, then another thread
+                  will call into this one via stop() to
+                  shutdown the (blocking) serve_forever()
+                - after serve_forever, effectively restart
+                  the loop, checking what values changed, and
+                  doing whatever is necessary
+                - land back into serve_forever
+                - rinse/repeat
+
+        '''
+        threading.current_thread().name = 'TwitchBotControl'
+
+        while not self.endthread:
+            logging.debug('Starting main loop')
+
+            while not self.isconfigured():
+                time.sleep(5)
+                if self.endthread:
+                    break
+
+            if self.endthread:
+                self.stop()
+                break
+            try:
+                self.server = TwitchBot(
+                    self.config.cparser.value('twitchbot/username'),
+                    self.config.cparser.value('twitchbot/clientid'),
+                    self.config.cparser.value('twitchbot/token'),
+                    self.config.cparser.value('twitchbot/channel'))
+            except Exception as error:  # pylint: disable=broad-except
+                logging.error('TwitchBot threw exception on create: %s', error)
+
+            try:
+                self.server.start()
+            except KeyboardInterrupt:
+                pass
+            except Exception as error:  # pylint: disable=broad-except
+                logging.error('Web server threw exception after forever: %s',
+                              error)
+            finally:
+                if self.server:
+                    self.server.shutdown()
+
+    def isconfigured(self):
+        ''' need everything configured! '''
+        return bool(
+            self.config.cparser.value('twitchbot/enabled', type=bool)
+            and self.config.cparser.value('twitchbot/username')
+            and self.config.cparser.value('twitchbot/clientid')
+            and self.config.cparser.value('twitchbot/token')
+            and self.config.cparser.value('twitchbot/channel'))
+
+    def stop(self, signum=None, frame=None):  #pylint: disable=unused-argument
+        ''' method to stop the thread '''
+        logging.debug('asked to stop or reconfigure')
+        if self.server:
+            self.server.shutdown()
+
+    def __del__(self):
+        logging.debug('thread is being killed!')
+        self.endthread = True
+        self.stop()
+
+
+def stop(pid):
+    ''' stop this process '''
+    logging.info('sending INT to %s', pid)
+    try:
+        os.kill(pid, signal.SIGINT)
+    except ProcessLookupError:
+        pass
+
+
+def start(orgname, appname, bundledir):
+    ''' multiprocessing start hook '''
+    threading.current_thread().name = 'TwitchBot'
+
+    if not orgname:
+        orgname = 'com.github.em1ran'
+
+    if not appname:
+        appname = 'NowPlaying'
+
+    if not bundledir:
+        if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+            bundledir = getattr(sys, '_MEIPASS',
+                                os.path.abspath(os.path.dirname(__file__)))
+        else:
+            bundledir = os.path.abspath(os.path.dirname(__file__))
+
+    QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
+    QCoreApplication.setOrganizationName(orgname)
+    QCoreApplication.setApplicationName(appname)
+    config = nowplaying.config.ConfigFile(bundledir=bundledir)
+    logging.info('boot up')
+    twitchbot = TwitchBotHandler(config)  # pylint: disable=unused-variable
+    twitchbot.run()
+
+
+def main():
+    ''' integration test '''
+    if len(sys.argv) != 5:
+        print("Usage: twitchbot <username> <client id> <token> <channel>")
+        sys.exit(1)
+
+    username = sys.argv[1]
+    client_id = sys.argv[2]
+    token = sys.argv[3]
+    channel = sys.argv[4]
+
+    orgname = 'com.github.em1ran'
+
+    appname = 'NowPlaying'
+
+    bundledir = os.path.abspath(os.path.dirname(__file__))
+
+    QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
+    QCoreApplication.setOrganizationName(orgname)
+    QCoreApplication.setApplicationName(appname)
+    # need to make sure config is initialized with something
+    nowplaying.config.ConfigFile(bundledir=bundledir)
+    bot = TwitchBot(username, client_id, token, channel)
+    bot.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/nowplaying/twitchbot.py
+++ b/nowplaying/twitchbot.py
@@ -213,7 +213,6 @@ class TwitchBot(irc.bot.SingleServerIRCBot):  # pylint: disable=too-many-instanc
         fullstring = event.arguments[0]
         profile = self._build_user_profile(event)
         metadata = {'cmduser': profile['display-name']}
-        print(profile)
         commands = fullstring.split()
         commands[0] = commands[0][1:]
         metadata['cmdtarget'] = []
@@ -230,21 +229,16 @@ class TwitchBot(irc.bot.SingleServerIRCBot):  # pylint: disable=too-many-instanc
         self.config.cparser.beginGroup(f'twitchbot-commands-{commands[0]}')
         perms = {}
         for key in self.config.cparser.childKeys():
-            print(f'reading {key}')
             perms[key] = self.config.cparser.value(key, type=bool)
         self.config.cparser.endGroup()
 
         allowed = True
         if perms:
-            print('got perms')
             allowed = False
             for usertype in perms.items():
                 if 'badgesdict' in profile and usertype in profile[
                         'badgesdict']:
-                    print(f'{usertype} in profile')
                     allowed = True
-        else:
-            print('no custom perms defined')
 
         if not allowed:
             return

--- a/nowplaying/webserver.py
+++ b/nowplaying/webserver.py
@@ -2,11 +2,15 @@
 ''' WebServer process '''
 
 import asyncio
-import os
 import logging
+import logging.config
+import os
+import secrets
+import signal
+import string
 import sys
-import time
 import threading
+import time
 import weakref
 
 import requests
@@ -16,9 +20,16 @@ import aiosqlite
 
 from PySide2.QtCore import QCoreApplication, QStandardPaths, Qt  # pylint: disable=no-name-in-module
 
+logging.config.dictConfig({
+    'version': 1,
+    'disable_existing_loggers': True,
+})
+
+#pylint: disable=wrong-import-position
+
+import nowplaying.bootstrap
 import nowplaying.config
 import nowplaying.db
-import nowplaying.bootstrap
 
 INDEXREFRESH = \
     '<!doctype html><html lang="en">' \
@@ -31,18 +42,27 @@ class WebHandler():
     def __init__(self, databasefile):
         threading.current_thread().name = 'WebServer'
         config = nowplaying.config.ConfigFile()
-        port = config.cparser.value('weboutput/httpport', type=int)
+        self.port = config.cparser.value('weboutput/httpport', type=int)
         enabled = config.cparser.value('weboutput/httpenabled', type=bool)
         self.databasefile = databasefile
 
         while not enabled:
-            time.sleep(5)
-            config.get()
-            enabled = config.cparser.value('weboutput/httpenabled', type=bool)
+            try:
+                time.sleep(5)
+                config.get()
+                enabled = config.cparser.value('weboutput/httpenabled',
+                                               type=bool)
+            except KeyboardInterrupt:
+                sys.exit(0)
 
+        self.magicstopurl = ''.join(
+            secrets.choice(string.ascii_letters) for i in range(32))
+        logging.info('Secret url to quit websever: %s', self.magicstopurl)
+
+        signal.signal(signal.SIGINT, self.forced_stop)
         self.loop = asyncio.get_event_loop()
         self.loop.run_until_complete(
-            self.start_server(host='0.0.0.0', port=port))
+            self.start_server(host='0.0.0.0', port=self.port))
         self.loop.run_forever()
 
     async def indexhtm_handler(self, request):  # pylint: disable=unused-argument
@@ -167,7 +187,7 @@ class WebHandler():
             web.get('/index.html', self.indexhtm_handler),
             web.get('/index.txt', self.indextxt_handler),
             web.get('/ws', self.websocket_handler),
-            web.get('/quit', self.stop_server)
+            web.get(f'/{self.magicstopurl}', self.stop_server)
         ])
         return web.AppRunner(app)
 
@@ -210,16 +230,28 @@ class WebHandler():
         await request.app.cleanup()
         self.loop.stop()
 
+    def forced_stop(self, signum, frame):  # pylint: disable=unused-argument
+        ''' caught an int signal so tell the world to stop '''
+        try:
+            requests.get(f'http://localhost:{self.port}/{self.magicstopurl}')
+        except Exception as error:  # pylint: disable=broad-except
+            logging.info(error)
 
-def stop():
+
+def stop(pid):
     ''' stop the web server -- called from Tray '''
-    config = nowplaying.config.ConfigFile()
-    port = config.cparser.value('weboutput/httpport', type=int)
-
+    logging.info('sending INT to %s', pid)
     try:
-        requests.get(f'http://localhost:{port}/quit')
-    except Exception as error:  # pylint: disable=broad-except
-        logging.info(error)
+        os.kill(pid, signal.SIGINT)
+    except ProcessLookupError:
+        pass
+    # config = nowplaying.config.ConfigFile()
+    # port = config.cparser.value('weboutput/httpport', type=int)
+
+    # try:
+    #     requests.get(f'http://localhost:{port}/quit')
+    # except Exception as error:  # pylint: disable=broad-except
+    #     logging.info(error)
 
 
 def start(orgname, appname, bundledir):

--- a/nowplaying/webserver.py
+++ b/nowplaying/webserver.py
@@ -20,12 +20,16 @@ import aiosqlite
 
 from PySide2.QtCore import QCoreApplication, QStandardPaths, Qt  # pylint: disable=no-name-in-module
 
+#
+# quiet down our imports
+#
+
 logging.config.dictConfig({
     'version': 1,
     'disable_existing_loggers': True,
 })
 
-#pylint: disable=wrong-import-position
+# pylint: disable=wrong-import-position
 
 import nowplaying.bootstrap
 import nowplaying.config
@@ -245,13 +249,6 @@ def stop(pid):
         os.kill(pid, signal.SIGINT)
     except ProcessLookupError:
         pass
-    # config = nowplaying.config.ConfigFile()
-    # port = config.cparser.value('weboutput/httpport', type=int)
-
-    # try:
-    #     requests.get(f'http://localhost:{port}/quit')
-    # except Exception as error:  # pylint: disable=broad-except
-    #     logging.info(error)
 
 
 def start(orgname, appname, bundledir):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiohttp==3.7.4.post0
 aiosqlite==0.17.0
+irc==19.0.1
 jinja2==2.11.3
 lxml==4.6.3
 obs-websocket-py==0.5.3
@@ -10,3 +11,4 @@ PySide2==5.15.2
 requests==2.25.1
 tinytag==1.5.0
 urllib3==1.26.4
+watchdog==2.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ packages = nowplaying
 install_requires =
   aiohttp==3.7.4.post0
   aiosqlite==0.17.0
+  irc==19.0.1
   jinja2==2.11.3
   lxml==4.6.3
   obs-websocket-py==0.5.3
@@ -19,6 +20,7 @@ install_requires =
   tinytag==1.5.0
   urllib3==1.26.4
   versioneer
+  watchdog==2.1.1
 
 [options.entry_points]
 console_scripts =

--- a/test_settingsui.py
+++ b/test_settingsui.py
@@ -33,7 +33,8 @@ class SettingsUI(QWidget):  # pylint: disable=too-few-public-methods
 
         self.qtui = _load_ui('settings')
         for basic in [
-                'general', 'source', 'webserver', 'obsws', 'serato', 'mpris2'
+                'general', 'source', 'webserver', 'obsws', 'twitchbot',
+                'serato', 'mpris2'
         ]:
             self.widgets[basic] = _load_ui(f'{basic}')
             try:


### PR DESCRIPTION
fixes #80 
fixes #129 

User-facing features:
* announces tracks on change
* template-d command structure allows for easy add/remove of commands
* templates understand multiple targets
* shouldn't interfere w/other bots
* select-able command character (e.g., instead of !cmd can use ^cmd if you want)

Internals:
* starting to converge on an output plugin system, but that will show up after this pr
* cleanup settingsui to have a generic template picker
* change stop methods for processes to take a pid and use signals
* sped up the process join()'s and add a close() which will hopefully fix the leaky semaphores
* reworked webserver start/stop/restart as a result
  * need to follow this up by randomizing the /quit URL. code is there, just need to put
    a value in it
  * SIGINT will do a clean shutdown (hopefully)

TO-DO:
* some code cleanup i'm sure
* Docs on how to get the token, etc.
